### PR TITLE
fix: restore Google index coverage (sitemap long-tail, edge caching, canonical)

### DIFF
--- a/webbsite/__init__.py
+++ b/webbsite/__init__.py
@@ -236,30 +236,21 @@ def create_app(config_class=Config):
             response.headers["CDN-Cache-Control"] = "max-age=604800"
             return response
 
-        # Data pages with ?d= = historical date snapshot
-        # CCASS history starts 2007-06-26; data for any past date is immutable.
-        # Recent dates (last 7 days) may still be revised, so cap their TTL.
+        # Data pages (.asp or directory index). The archive is frozen (data ends
+        # 2025-10-10), so every page is immutable. Cache hard at the edge so
+        # crawlers/users hit warm Cloudflare instead of a ~1s origin render on
+        # every unique ?p=<id>; a ?d= older than a year gets an even longer TTL.
         if path.endswith(".asp") or path.endswith("/"):
             d_param = request.args.get("d", "")
-            ttl_browser = 3600
-            ttl_edge = 3600
+            ttl_browser = 86400      # 1 day
+            ttl_edge = 2592000       # 30 days
             if d_param and len(d_param) == 10:
                 try:
-                    from datetime import datetime, date as _date, timedelta
+                    from datetime import datetime, date as _date
                     parsed = datetime.strptime(d_param, "%Y-%m-%d").date()
-                    age = (_date.today() - parsed).days
-                    if age > 365:
-                        # >1 year old: definitely immutable
+                    if (_date.today() - parsed).days > 365:
                         ttl_browser = 604800       # 7 days
                         ttl_edge = 31536000        # 1 year
-                    elif age > 30:
-                        # 30 days – 1 year: stable
-                        ttl_browser = 86400        # 1 day
-                        ttl_edge = 2592000         # 30 days
-                    elif age > 7:
-                        # 7–30 days: very unlikely to change
-                        ttl_browser = 14400        # 4 hours
-                        ttl_edge = 604800          # 7 days
                 except ValueError:
                     pass
             response.headers.setdefault("Cache-Control", f"public, max-age={ttl_browser}")
@@ -273,6 +264,10 @@ def create_app(config_class=Config):
     def _inject_now():
         from datetime import date as _date
         return {"now": _date.today()}
+
+    # Expose canonical_query() to templates (base.html builds rel=canonical from it).
+    from webbsite.asp_helpers import canonical_query
+    app.jinja_env.globals["canonical_query"] = canonical_query
 
     # Custom error handlers
     from webbsite.db import QueryTimeoutError

--- a/webbsite/asp_helpers.py
+++ b/webbsite/asp_helpers.py
@@ -4,9 +4,31 @@ Direct ports to maintain compatibility with ASP logic
 """
 
 from datetime import datetime, date
+from urllib.parse import urlencode
 from flask import request
 import re
 import html
+
+
+# ===== CANONICAL URL =====
+
+# Presentation-only query params: they change how a page is sorted/expanded, not
+# which underlying record it shows. Stripping them from rel=canonical consolidates
+# the sort/hide/view variants of a page onto one canonical URL (the form seeded in
+# the sitemap), instead of letting each facet combination be its own indexed page.
+# Denylist (not allowlist): unknown params are kept, so genuine content params
+# (p, d, a, i, part, ...) still keep distinct pages distinct.
+CANONICAL_DROP_PARAMS = frozenset({"sort", "so", "s2", "hide", "h", "x", "n", "m", "f"})
+
+
+def canonical_query() -> str:
+    """Query string for rel=canonical, with presentation-only params removed."""
+    kept = [
+        (k, v)
+        for k, v in request.args.items(multi=True)
+        if k.lower() not in CANONICAL_DROP_PARAMS
+    ]
+    return urlencode(kept)
 
 
 # ===== REQUEST PARAMETER HELPERS =====

--- a/webbsite/routes/sitemap.py
+++ b/webbsite/routes/sitemap.py
@@ -28,6 +28,7 @@ bp = Blueprint("sitemap", __name__)
 
 _URLS_PER_SITEMAP = 50000  # sitemaps.org protocol cap
 _cache: dict[str, list[str]] = {}  # data is static -> memoise per worker
+DATA_FREEZE = "2025-10-10"  # data collection ended here; every page's <lastmod>
 
 
 def _host() -> str:
@@ -70,10 +71,56 @@ def _company_paths() -> list[str]:
     return [f"/dbpub/orgdata.asp?p={r['personid']}" for r in rows]
 
 
-# child-sitemap registry: name -> callable returning an ordered list of paths
+def _sfc_firm_paths() -> list[str]:
+    """SFClicensees.asp?p=<orgid> — every firm that has SFC licence records."""
+    rows = execute_query(
+        "SELECT DISTINCT orgid FROM enigma.olicrec ORDER BY orgid"
+    )
+    return [f"/dbpub/SFClicensees.asp?p={r['orgid']}" for r in rows]
+
+
+def _sfc_person_paths() -> list[str]:
+    """sfclicrec.asp?p=<staffid> — every SFC-licensed individual."""
+    rows = execute_query(
+        "SELECT DISTINCT staffid FROM enigma.licrec ORDER BY staffid"
+    )
+    return [f"/dbpub/sfclicrec.asp?p={r['staffid']}" for r in rows]
+
+
+def _natperson_paths() -> list[str]:
+    """natperson.asp?p=<personid>, scoped to HK-relevant natural persons.
+
+    Officers of HK-ever-listed companies (reusing the same listedcoshkever filter
+    as _company_paths) plus SFC licensees. The people joins guarantee each id is a
+    natural person, not a corporate director, and exclude the ~19.5M global
+    Companies House persons that have no HK connection.
+    """
+    rows = execute_query(
+        """
+        SELECT personid FROM (
+            SELECT DISTINCT d.director AS personid
+            FROM enigma.directorships d
+            JOIN enigma.people pe         ON pe.personid = d.director
+            JOIN enigma.listedcoshkever l ON l.personid = d.company
+            UNION
+            SELECT DISTINCT lr.staffid
+            FROM enigma.licrec lr
+            JOIN enigma.people pe ON pe.personid = lr.staffid
+        ) t
+        ORDER BY personid
+        """
+    )
+    return [f"/dbpub/natperson.asp?p={r['personid']}" for r in rows]
+
+
+# child-sitemap registry: name -> callable returning an ordered list of paths.
+# Names are hyphen-free so the /sitemap-<name>-<int:page>.xml route stays unambiguous.
 _SOURCES = {
     "pages": _static_page_paths,
     "companies": _company_paths,
+    "sfcfirms": _sfc_firm_paths,
+    "sfcpersons": _sfc_person_paths,
+    "people": _natperson_paths,
 }
 
 
@@ -121,7 +168,8 @@ def sitemap_child(name: str, page: int) -> Response:
     host = _host()
     chunk = paths[start:start + _URLS_PER_SITEMAP]
     items = "".join(
-        f"<url><loc>https://{host}{escape(p)}</loc></url>" for p in chunk
+        f"<url><loc>https://{host}{escape(p)}</loc><lastmod>{DATA_FREEZE}</lastmod></url>"
+        for p in chunk
     )
     return _xml_response(
         f'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">{items}</urlset>'

--- a/webbsite/templates/base.html
+++ b/webbsite/templates/base.html
@@ -5,8 +5,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>{% block title %}Renavon Hong Kong Database{% endblock %}</title>
 <meta name="description" content="{% block description %}35 years of Hong Kong financial-market data — listed companies, directors, shareholders, CCASS holdings and corporate filings. A free, open archive of the late David Webb's Webb-site.com, released under CC-BY 4.0.{% endblock %}">
-{# Self-canonical (full path + query) so distinct pages stay distinct; one host, set via CANONICAL_HOST. #}
-{%- set _qs = request.query_string.decode() %}
+{# Canonical: full path + content query, with presentation-only params (sort/hide/view)
+   dropped so facet variants consolidate onto one indexed URL. One host, via CANONICAL_HOST. #}
+{%- set _qs = canonical_query() %}
 <link rel="canonical" href="https://{{ config.CANONICAL_HOST }}{{ request.path }}{% if _qs %}?{{ _qs }}{% endif %}">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Renavon Hong Kong Database">


### PR DESCRIPTION
## Why

May 2026 organic traffic to **webbsite.renavon.com** dropped sharply. Diagnosis via PostHog + Google Search Console: **not a ranking penalty** (average position held at ~8 throughout) but an **index-coverage / crawl-budget regression** after the Render→DigitalOcean migration reduced crawl throughput. The `SFClicensees.asp?p=` cohort lost **43% of its distinct indexed pages** (15,157 → 8,658) while surviving pages kept their rank — i.e. pages *aged out of the index*.

Three root causes, confirmed by reading the code and probing the live origin:

1. **Long-tail absent from the sitemap.** `sitemap.py` only emitted `pages` + `companies` (`orgdata.asp?p=`). The high-traffic detail pages relied on crawl discovery alone, so when crawl slowed they weren't re-found.
2. **Deep `?p=` pages uncacheable at the edge.** The TTL handler only lengthened TTL for a `?d=` date param; `?p=` pages fell through to `max-age=3600`, a Cloudflare MISS at ~1s origin each — expensive for crawlers. The archive is frozen, so the short TTL served no purpose.
3. **Faceted-URL explosion.** Self-canonical included the full query string, so every sort/hide/view variant was its own canonical — wasting crawl budget on near-duplicates.

## What

- **Sitemap** (`webbsite/routes/sitemap.py`): add three long-tail sources mirroring `_company_paths` — `sfcfirms` (`SFClicensees.asp?p=`, `DISTINCT orgid` in `olicrec`), `sfcpersons` (`sfclicrec.asp?p=`, `DISTINCT staffid` in `licrec`), `people` (`natperson.asp?p=`, **HK-scoped**: officers of HK-ever-listed companies via `listedcoshkever` + SFC licensees, joined to `people` so never the ~19.5M global CH rows). Tag every `<url>` with `<lastmod>2025-10-10`.
- **Caching** (`webbsite/__init__.py`): raise the data-page baseline from `3600` to **1d browser / 30d edge**; collapse the obsolete `?d=` "may be revised" ladder to a single `>1y → 1y` escalation (its 7d branch had fallen below the new floor).
- **Canonical** (`asp_helpers.py` + `base.html`): strip presentation-only params (`sort/so/s2/hide/h/x/n/m/f`) from `rel=canonical` so facet variants consolidate onto the `?p=` URL the sitemap seeds.

No new dependencies, no schema changes.

## Verification

Local (no enigma DB on dev machine — logic only): app builds, `base.html` compiles, `canonical_query()` strips the right params (`?p=X&a=0&h=Y&so=namup` → `p=X&a=0`), all 5 sitemap child routes resolve, TTLs emit as intended (`?p=`→30d edge, old `?d=`→1y, `/health`→`no-store`).

Post-deploy on the box (confirms counts/timing, per the module docstring): `GET /sitemap.xml` lists the 3 new children; child sitemaps are non-empty with sane sizes; `?p=` page returns `CDN-Cache-Control: max-age=2592000`; faceted URL's canonical omits dropped params. Then purge Cloudflare and resubmit sitemaps in GSC; watch Coverage/Crawl-stats recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)