### PR TITLE
fix: sanitize/parameterize full-text search to_tsquery (500 on punctuation)

### DIFF
--- a/webbsite/asp_helpers.py
+++ b/webbsite/asp_helpers.py
@@ -21,6 +21,20 @@ import html
 CANONICAL_DROP_PARAMS = frozenset({"sort", "so", "s2", "hide", "h", "x", "n", "m", "f"})
 
 
+_TS_NONWORD = re.compile(r"\W+", re.UNICODE)
+
+
+def ts_words(text: str) -> list[str]:
+    """Split user text into safe to_tsquery lexemes.
+
+    Keeps only Unicode word characters (letters/digits/_, including CJK), so
+    tsquery operator/punctuation characters in user input (& | ! ( ) : * < > '
+    ") can neither break to_tsquery parsing nor inject. Empty tokens are dropped.
+    Callers assemble these into a tsquery with their own (trusted) operators.
+    """
+    return [w for w in (_TS_NONWORD.sub("", part) for part in text.split()) if w]
+
+
 def canonical_query() -> str:
     """Query string for rel=canonical, with presentation-only params removed."""
     kept = [

--- a/webbsite/routes/dbpub/statistics.py
+++ b/webbsite/routes/dbpub/statistics.py
@@ -2579,21 +2579,17 @@ def govac_search():
     if n:
         # Build search query based on search type
         if st == "a":
-            # Full-text search using PostgreSQL to_tsquery
-            # Convert space-separated terms to '&' (AND) query
-            terms = n.split()
-            if terms:
-                # Create tsquery format: term1 & term2 & term3
-                tsquery = " & ".join(terms)
-
+            # Full-text search. plainto_tsquery parses arbitrary user text into
+            # an AND query (bound param), so punctuation/operators can't break it.
+            if n.split():
                 sql = """
                     SELECT id, txt, parentid
                     FROM enigma.govitems
-                    WHERE to_tsvector('simple', txt) @@ to_tsquery('simple', %s)
+                    WHERE to_tsvector('simple', txt) @@ plainto_tsquery('simple', %s)
                     ORDER BY txt
                     LIMIT %s
                 """
-                results = execute_query(sql, (tsquery, limit))
+                results = execute_query(sql, (n, limit))
         else:
             # Left match using LIKE
             sql = """
@@ -5859,10 +5855,10 @@ def searchess():
     if n:
         # Build WHERE clause based on search type
         if st == "a":
-            # Full-text search - convert space-separated words to AND query
-            search_terms = " & ".join(n.split())
-            where_clause = "to_tsvector('simple', ename) @@ to_tsquery('simple', %s)"
-            params = (search_terms,)
+            # Full-text search. plainto_tsquery parses arbitrary user text into
+            # an AND query (bound param), so punctuation/operators can't break it.
+            where_clause = "to_tsvector('simple', ename) @@ plainto_tsquery('simple', %s)"
+            params = (n,)
         else:  # st == 'l' for left match
             where_clause = "ename LIKE %s"
             params = (n + "%",)

--- a/webbsite/routes/search.py
+++ b/webbsite/routes/search.py
@@ -4,7 +4,7 @@ Search routes - Direct port from searchorgs.asp and searchpeople.asp
 
 from flask import Blueprint, render_template, request
 from webbsite.db import execute_query
-from webbsite.asp_helpers import rem_space, get_str, get_bool, apos
+from webbsite.asp_helpers import rem_space, get_str, get_bool, apos, ts_words
 
 bp = Blueprint("search", __name__)
 
@@ -42,17 +42,16 @@ def search_orgs():
     old_results = []
 
     if n:
-        # Build WHERE clause based on search type
+        # Build WHERE clause based on search type. Full-text uses plainto_tsquery
+        # (bound param), which parses arbitrary user text into an AND query and
+        # can't be broken by tsquery operator/punctuation chars.
         if st == "a":
-            # Full-text search - PostgreSQL syntax
-            # Convert space-separated terms to term1 & term2 format for tsquery
-            terms = " & ".join(n.split())
-            match_clause = (
-                f"to_tsvector('simple', name1) @@ to_tsquery('simple', '{apos(terms)}')"
-            )
+            match_clause = "to_tsvector('simple', name1) @@ plainto_tsquery('simple', %s)"
+            org_params = (n,)
         else:
             # Left match (starts with) - use LOWER() + LIKE for case-insensitive with pattern index
             match_clause = f"LOWER(name1) LIKE LOWER('{apos(n)}%')"
+            org_params = None
 
         # Search current names
         # Use CTE to force pattern index usage, then inline everListCo() logic
@@ -77,11 +76,11 @@ def search_orgs():
             ORDER BY {ob}
             LIMIT {limit}
         """
-        current_results = execute_query(sql)
+        current_results = execute_query(sql, org_params)
 
         # Search old names
         if st == "a":
-            old_match_clause = f"to_tsvector('simple', oldName) @@ to_tsquery('simple', '{apos(terms)}')"
+            old_match_clause = "to_tsvector('simple', oldName) @@ plainto_tsquery('simple', %s)"
         else:
             old_match_clause = f"LOWER(oldName) LIKE LOWER('{apos(n)}%')"
 
@@ -107,7 +106,7 @@ def search_orgs():
             ORDER BY {ob}
             LIMIT {limit}
         """
-        old_results = execute_query(sql)
+        old_results = execute_query(sql, org_params)
 
     return render_template(
         "searchorgs.html",
@@ -163,48 +162,62 @@ def search_people():
                 where_current += f" AND dn2 = '{apos(n2)}'"
                 where_alias += f" AND a.dn2 = '{apos(n2)}'"
         else:
-            # Full-text search mode
+            # Full-text search mode. User words are reduced to safe tsquery
+            # lexemes (ts_words); the &/|/() operators below are ours, so the
+            # assembled tsquery is always valid and is passed as a bound param.
+            fname_words = ts_words(n1) if n1 else []
+            forename_words = ts_words(n2) if n2 else []
+
             # Build family name search term
-            fname = ""
-            if n1:
-                fname = " & ".join(f'"{word}"' for word in n1.split())
+            fname = " & ".join(f'"{w}"' for w in fname_words)
 
             # Build given names search term (with multi-word logic)
             forename = ""
-            if n2:
-                words = n2.split()
-                if len(words) == 1:
-                    forename = f'"{words[0]}"'
-                elif len(words) > 1:
-                    # Build list of terms to avoid leading & operator
-                    forename_parts = []
-                    # Add all words except last two as required
-                    for word in words[:-2]:
-                        forename_parts.append(f'"{word}"')
-                    # Last two words: search both separate and combined
-                    # e.g., "Xiao Ping" searches for (("Xiao" & "Ping") | "XiaoPing")
-                    forename_parts.append(
-                        f'(("{words[-2]}" & "{words[-1]}") | "{words[-2] + words[-1]}")'
-                    )
-                    forename = " & ".join(forename_parts)
+            if len(forename_words) == 1:
+                forename = f'"{forename_words[0]}"'
+            elif len(forename_words) > 1:
+                # Build list of terms to avoid leading & operator
+                forename_parts = [f'"{w}"' for w in forename_words[:-2]]
+                # Last two words: search both separate and combined
+                # e.g., "Xiao Ping" searches for (("Xiao" & "Ping") | "XiaoPing")
+                forename_parts.append(
+                    f'(("{forename_words[-2]}" & "{forename_words[-1]}") '
+                    f'| "{forename_words[-2] + forename_words[-1]}")'
+                )
+                forename = " & ".join(forename_parts)
 
+            # Collect tsquery values in placeholder order (shared by both the
+            # current-names and alias queries, which mirror each other).
+            ts_params = []
             if d:
                 # Match family and given names separately
                 where_current = "1=1"
                 where_alias = "1=1"
-                if n1:
-                    where_current += f" AND to_tsvector('simple', dn1) @@ to_tsquery('simple', '{apos(fname)}')"
-                    where_alias += f" AND to_tsvector('simple', a.dn1) @@ to_tsquery('simple', '{apos(fname)}')"
-                if n2:
-                    where_current += f" AND to_tsvector('simple', dn2) @@ to_tsquery('simple', '{apos(forename)}')"
-                    where_alias += f" AND to_tsvector('simple', a.dn2) @@ to_tsquery('simple', '{apos(forename)}')"
+                if fname:
+                    where_current += " AND to_tsvector('simple', dn1) @@ to_tsquery('simple', %s)"
+                    where_alias += " AND to_tsvector('simple', a.dn1) @@ to_tsquery('simple', %s)"
+                    ts_params.append(fname)
+                if forename:
+                    where_current += " AND to_tsvector('simple', dn2) @@ to_tsquery('simple', %s)"
+                    where_alias += " AND to_tsvector('simple', a.dn2) @@ to_tsquery('simple', %s)"
+                    ts_params.append(forename)
             else:
                 # Match across both fields
                 combined = fname
                 if forename:
                     combined = combined + " & " + forename if combined else forename
-                where_current = f"to_tsvector('simple', COALESCE(dn1, '') || ' ' || COALESCE(dn2, '')) @@ to_tsquery('simple', '{apos(combined)}')"
-                where_alias = f"to_tsvector('simple', COALESCE(a.dn1, '') || ' ' || COALESCE(a.dn2, '')) @@ to_tsquery('simple', '{apos(combined)}')"
+                if combined:
+                    where_current = "to_tsvector('simple', COALESCE(dn1, '') || ' ' || COALESCE(dn2, '')) @@ to_tsquery('simple', %s)"
+                    where_alias = "to_tsvector('simple', COALESCE(a.dn1, '') || ' ' || COALESCE(a.dn2, '')) @@ to_tsquery('simple', %s)"
+                    ts_params.append(combined)
+                else:
+                    # User input sanitised to nothing -> no full-text match.
+                    where_current = "1=0"
+                    where_alias = "1=0"
+
+        # In exact mode the where clauses carry no placeholders; pass None so
+        # psycopg2 doesn't treat any literal % as a format spec.
+        people_params = tuple(ts_params) or None if not e else None
 
         # Query current names
         sql = f"""
@@ -215,7 +228,7 @@ def search_people():
             ORDER BY name1, name2
             LIMIT 500
         """
-        current_results = execute_query(sql)
+        current_results = execute_query(sql, people_params)
 
         # Format birth dates for display
         for row in current_results:
@@ -242,7 +255,7 @@ def search_people():
             ORDER BY a.n1, a.n2
             LIMIT 500
         """
-        alias_results = execute_query(sql)
+        alias_results = execute_query(sql, people_params)
 
         # Format birth dates for alias results
         for row in alias_results:


### PR DESCRIPTION
## Why
The public full-text search routes fed raw user words into `to_tsquery()`, whose operator syntax (`& | ! ( ) : * < > " '`) is **not** escaped by `apos()`. Any search term containing punctuation returned a 500. Found in the production logs:

```
GET /dbpub/searchpeople.asp?n1=Liu&n2=<script>alert('XSS')</script>  -> 500
psycopg2.errors.SyntaxError: syntax error in tsquery: ""Liu" & "<script>alert('XSS')</script>""
```

Parameterization alone wouldn't fix it — the error is tsquery *syntax*, not SQL injection (though the f-string construction was also an injection surface).

## What
Affects all four public full-text search endpoints (the auth-gated `dbeditor` search, 410 in this read-only deploy, is left untouched):

- **`searchpeople.asp`** keeps its OR/combined-name logic `(("Xiao" & "Ping") | "XiaoPing")`, but each user *word* is reduced to a safe lexeme via new `asp_helpers.ts_words()` (Unicode word chars only, incl. CJK) before being wrapped in our trusted operators; the assembled tsquery is passed as a bound param. Input that sanitizes to nothing now yields no match instead of erroring.
- **`searchorgs.asp`**, **`govactsearch`**, **gov-payments name search** are simple AND queries → switched to `plainto_tsquery('simple', %s)` (parses arbitrary text safely, same AND semantics).

## Verification
`ts_words`: `"<script>alert('XSS')</script>"` → `["scriptalertXSSscript"]`; `"張 三"` → `["張","三"]`; all-punctuation → `[]`. Confirmed against the prod DB that the resulting tsqueries parse (`'"Liu"'`→`'liu'`, CJK preserved, complex OR query unchanged). End-to-end HTTP checks (attack input → 200, normal/CJK names → results) to run on the box post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)