### PR TITLE
fix: enigma.events.asp dict-row indexing (wrong name, broken company link)

### DIFF
--- a/webbsite/routes/dbpub/events.py
+++ b/webbsite/routes/dbpub/events.py
@@ -44,7 +44,7 @@ def enigma_events():
                 (stock_code,),
             )
             if result and len(result) > 0:
-                issue_id = result[0][0]
+                issue_id = result[0]["issueid"]
         except Exception as ex:
             current_app.logger.error(
                 f"Error looking up stock code for enigma.events: {ex}"
@@ -65,8 +65,8 @@ def enigma_events():
                 (issue_id,),
             )
             if result and len(result) > 0:
-                stock_name = result[0][0]
-                person_id = result[0][1]
+                stock_name = result[0]["name1"]
+                person_id = result[0]["personid"]
         except Exception as ex:
             current_app.logger.error(
                 f"Error getting stock name for enigma.events: {ex}"


### PR DESCRIPTION
## Why
`execute_query` returns dict rows (`db.py:109`), but `enigma.events.asp` indexed them positionally — `result[0][0]`, `result[0][1]` — raising `KeyError(0)`, logged as `Error getting stock name for enigma.events: 0`. The `except` swallowed it, so **every** events page for a valid issue degraded:
- title showed `Issue <n>` instead of the company name
- `person_id` stayed `0` → broken company link `orgdata.asp?p=0`

Reproduced on the box: `enigma.events.asp?i=1456` showed "Events: Issue 1456" / `orgdata.asp?p=0`, while the DB has "Congyu Intelligent Agricultural Holdings Limited" (personid 6044).

## What
Use dict keys: `result[0]["issueid"]` (stock-code lookup) and `result[0]["name1"]` / `result[0]["personid"]` (name lookup). Swept the routes tree — no other positional dict-row indexing remains (the `statistics.py` `adjustments[0][0]` are tuple lists, correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)