### PR TITLE
feat(bridge): contextual, click-tracked Renavon cross-sell

### DIFF
--- a/webbsite/templates/base.html
+++ b/webbsite/templates/base.html
@@ -30,10 +30,8 @@
 {% block extra_head %}{% endblock %}
 </head>
 <body>
-<div id="renavon-banner" style="background:#1a1a2e;border-bottom:2px solid #0891b2;padding:8px 16px;text-align:center;font-family:Arial,sans-serif;font-size:13px;">
-    <span style="color:#e2e8f0;">Need bulk access to HK company data?</span>
-    <a href="https://renavon.com/packages/hk-companies?utm_source=webbsite&utm_medium=banner&utm_campaign=cross_sell" target="_blank" rel="noopener" style="color:#22d3ee;text-decoration:underline;font-weight:bold;margin-left:6px;">Query 3M+ companies via SQL, CSV, or API on Renavon</a>
-</div>
+{# Contextual Renavon cross-sell (per-page-type target, click-tracked). See includes/_renavon_cta.html #}
+{% include 'includes/_renavon_cta.html' %}
 {% block header %}{% endblock %}
 {% block content %}{% endblock %}
 {% include 'includes/footer.html' %}

--- a/webbsite/templates/includes/_renavon_cta.html
+++ b/webbsite/templates/includes/_renavon_cta.html
@@ -43,6 +43,6 @@
     <span style="color:#e2e8f0;">This is a free archive, frozen at 10&nbsp;Oct&nbsp;2025. For a live, maintained {{ _what }} &mdash; bulk CSV/Excel and API &mdash;</span>
     <a href="{{ _url }}?utm_source=webbsite&amp;utm_medium=cta&amp;utm_campaign=bridge&amp;ref=webbsite&amp;ref_path={{ request.path | urlencode }}"
        target="_blank" rel="noopener"
-       onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:'{{ _ds }}',source_path:'{{ request.path }}'})}"
+       onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:{{ _ds | tojson }},source_path:{{ request.path | tojson }}})}"
        style="color:#22d3ee;text-decoration:underline;font-weight:bold;margin-left:6px;">{{ _cta }} &rarr;</a>
 </div>

--- a/webbsite/templates/includes/_renavon_cta.html
+++ b/webbsite/templates/includes/_renavon_cta.html
@@ -1,0 +1,39 @@
+{#
+  Renavon cross-sell — a CONTEXTUAL bridge from the (frozen) Webb-site archive to
+  Renavon's live, maintained datasets.
+
+  Context for editors:
+  - Webb-site is the late David Webb's data, released CC-BY 4.0 and served here as
+    a free, read-only archive FROZEN at 2025-10-10.
+  - Renavon maintains its OWN live pipelines for the same public sources (SFC,
+    HKEX, Companies Registry). So this is an honest "the archive is frozen; here's
+    the live version" pointer — NOT a resell of the CC-BY archive.
+  - Keep the tone understated out of respect for the archive.
+
+  This replaces the earlier hardcoded, generic, untracked banner that pointed at
+  /packages/hk-companies (a de-listed package during the CRHK rebuild → 0 convs).
+  Click-through is captured explicitly because PostHog autocapture is off site-wide.
+
+  To extend (A2): add elif branches mapping more page families to LIVE datasets
+  (e.g. SDI → hkex_disclosures, org/person → hkex_directors / crhk_companies once
+  re-listed). Only point at datasets that are visible:true on renavon.com.
+#}
+{%- set _path = request.path | lower -%}
+{%- if 'sfc' in _path -%}
+  {%- set _url = 'https://renavon.com/data/sfc/sfc_licences' -%}
+  {%- set _what = 'directory of SFC-licensed firms and representatives' -%}
+  {%- set _cta = 'see the live data on Renavon' -%}
+  {%- set _ds = 'sfc_licences' -%}
+{%- else -%}
+  {%- set _url = 'https://renavon.com/datasets' -%}
+  {%- set _what = 'set of Hong Kong financial datasets' -%}
+  {%- set _cta = 'explore the live data on Renavon' -%}
+  {%- set _ds = 'catalog' -%}
+{%- endif -%}
+<div id="renavon-banner" style="background:#1a1a2e;border-bottom:2px solid #0891b2;padding:8px 16px;text-align:center;font-family:Arial,sans-serif;font-size:13px;">
+    <span style="color:#e2e8f0;">This is a free archive, frozen at 10&nbsp;Oct&nbsp;2025. For a live, maintained {{ _what }} &mdash; bulk CSV/Excel and API &mdash;</span>
+    <a href="{{ _url }}?utm_source=webbsite&amp;utm_medium=cta&amp;utm_campaign=bridge&amp;ref=webbsite&amp;ref_path={{ request.path | urlencode }}"
+       target="_blank" rel="noopener"
+       onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:'{{ _ds }}',source_path:'{{ request.path }}'})}"
+       style="color:#22d3ee;text-decoration:underline;font-weight:bold;margin-left:6px;">{{ _cta }} &rarr;</a>
+</div>

--- a/webbsite/templates/includes/_renavon_cta.html
+++ b/webbsite/templates/includes/_renavon_cta.html
@@ -14,22 +14,31 @@
   /packages/hk-companies (a de-listed package during the CRHK rebuild → 0 convs).
   Click-through is captured explicitly because PostHog autocapture is off site-wide.
 
-  To extend (A2): add elif branches mapping more page families to LIVE datasets
-  (e.g. SDI → hkex_disclosures, org/person → hkex_directors / crhk_companies once
-  re-listed). Only point at datasets that are visible:true on renavon.com.
+  Page → dataset mapping is by blueprint (robust) with a path fallback for the
+  org/people pages served out of the grab-bag dbpub_statistics blueprint. Only
+  point at datasets that are visible:true on renavon.com — all targets below are
+  verified live (HTTP 200). CRHK company/director targets wait on the rebuild.
 #}
+{%- set _bp = request.blueprint or '' -%}
 {%- set _path = request.path | lower -%}
-{%- if 'sfc' in _path -%}
+{%- if _bp == 'dbpub_sfc' or 'sfc' in _path -%}
   {%- set _url = 'https://renavon.com/data/sfc/sfc_licences' -%}
   {%- set _what = 'directory of SFC-licensed firms and representatives' -%}
-  {%- set _cta = 'see the live data on Renavon' -%}
   {%- set _ds = 'sfc_licences' -%}
+{%- elif _bp == 'dbpub_sdi' or 'sdi' in _path -%}
+  {%- set _url = 'https://renavon.com/data/hkex/hkex_disclosures' -%}
+  {%- set _what = 'record of HKEX insider dealing and substantial-shareholding disclosures' -%}
+  {%- set _ds = 'hkex_disclosures' -%}
+{%- elif _bp in ['dbpub_corporate', 'dbpub_people'] or 'natperson' in _path or 'orgdata' in _path or 'advisers' in _path or 'adviserships' in _path or 'searchorg' in _path or 'searchpeople' in _path -%}
+  {%- set _url = 'https://renavon.com/data/hkex/hkex_directors' -%}
+  {%- set _what = 'directory of HKEX-listed company directors and boards' -%}
+  {%- set _ds = 'hkex_directors' -%}
 {%- else -%}
   {%- set _url = 'https://renavon.com/datasets' -%}
   {%- set _what = 'set of Hong Kong financial datasets' -%}
-  {%- set _cta = 'explore the live data on Renavon' -%}
   {%- set _ds = 'catalog' -%}
 {%- endif -%}
+{%- set _cta = 'explore the live data on Renavon' if _ds == 'catalog' else 'see the live data on Renavon' -%}
 <div id="renavon-banner" style="background:#1a1a2e;border-bottom:2px solid #0891b2;padding:8px 16px;text-align:center;font-family:Arial,sans-serif;font-size:13px;">
     <span style="color:#e2e8f0;">This is a free archive, frozen at 10&nbsp;Oct&nbsp;2025. For a live, maintained {{ _what }} &mdash; bulk CSV/Excel and API &mdash;</span>
     <a href="{{ _url }}?utm_source=webbsite&amp;utm_medium=cta&amp;utm_campaign=bridge&amp;ref=webbsite&amp;ref_path={{ request.path | urlencode }}"


### PR DESCRIPTION
## What
Replace the global Renavon cross-sell banner with a **contextual, click-tracked** partial (`includes/_renavon_cta.html`).

## Why
The prior banner (added 2026-04-02) pointed *every* page at `/packages/hk-companies` — a package de-listed during the CRHK rebuild (it 302-bounces) — and was generic + untracked. Measured over 90 days via PostHog: **31 click-throughs (~0.05% CTR), 0 conversions.**

## Change
Per-page-type targets, all verified HTTP 200:
- **SFC pages** → `/data/sfc/sfc_licences` (highest-traffic cluster, ~10k views/mo)
- **SDI pages** → `/data/hkex/hkex_disclosures`
- **corporate / people / org pages** → `/data/hkex/hkex_directors`
- **everything else** → `/datasets` (instead of the dead package)

Plus:
- Explicit `posthog.capture('bridge_cta_click', …)` — site-wide autocapture is off, so the banner was previously untracked
- UTM `utm_source=webbsite&utm_medium=cta&utm_campaign=bridge` + `ref_path` for per-page attribution

Mapping is blueprint-primary with a path fallback for org/people pages served by the grab-bag `dbpub_statistics` blueprint.

Framing is deliberately understated: the archive is frozen at 2025-10-10; Renavon runs its own live SFC/HKEX/CR pipelines, so this points to the *live* version — not a resell of the CC-BY archive.

CRHK company/director targets wait on the rebuild sign-off (A3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)