### PR TITLE
fix(bridge): repair bridge_cta_click handler

### DIFF
--- a/webbsite/templates/includes/_renavon_cta.html
+++ b/webbsite/templates/includes/_renavon_cta.html
@@ -43,6 +43,6 @@
     <span style="color:#e2e8f0;">This is a free archive, frozen at 10&nbsp;Oct&nbsp;2025. For a live, maintained {{ _what }} &mdash; bulk CSV/Excel and API &mdash;</span>
     <a href="{{ _url }}?utm_source=webbsite&amp;utm_medium=cta&amp;utm_campaign=bridge&amp;ref=webbsite&amp;ref_path={{ request.path | urlencode }}"
        target="_blank" rel="noopener"
-       onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:{{ _ds | tojson }},source_path:{{ request.path | tojson }}})}"
+       onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:'{{ _ds }}',source_path:location.pathname})}"
        style="color:#22d3ee;text-decoration:underline;font-weight:bold;margin-left:6px;">{{ _cta }} &rarr;</a>
 </div>


### PR DESCRIPTION
`bridge_cta_click` has been firing **0** events since the contextual CTA shipped — despite UTM-attributed clicks (medium=cta) and a real conversion (Burford Capital).

**Cause:** the XSS hardening switched the onclick payload to `| tojson`, which emits *double-quoted* JSON inside the *double-quoted* `onclick="..."` attribute → the inner `"` closes the attribute → malformed handler → never fires.

**Fix:** `target_dataset:'{{ _ds }}'` (a controlled literal — `sfc_licences`/`hkex_disclosures`/`hkex_directors`/`catalog`, no user input, safe single-quoted) and `source_path:location.pathname` (read client-side — no `request.path` injection at all). XSS-safe **and** functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)