### PR TITLE
Link HK company numbers to crhk.guru company pages

### DIFF
--- a/tests/test_crhk.py
+++ b/tests/test_crhk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Unit tests for webbsite.crhk.crhk_company_url.
+
+Pure-function tests — no Flask app, no database, no network. Run from the repo
+root so ``webbsite`` is importable:
+
+    uv run python tests/test_crhk.py
+
+Exits non-zero if any case fails.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from webbsite.crhk import crhk_company_url
+
+# (input, expected) pairs covering every branch of the helper.
+CASES = [
+    # 8-digit BRN -> /company/brn/{v}
+    ("12345678", "https://crhk.guru/company/brn/12345678"),
+    ("00000001", "https://crhk.guru/company/brn/00000001"),
+    # 1-7 digit CR number -> zero-padded to 7 -> /company/{v}
+    ("1", "https://crhk.guru/company/0000001"),
+    ("123", "https://crhk.guru/company/0000123"),
+    ("1234567", "https://crhk.guru/company/1234567"),
+    ("0001234", "https://crhk.guru/company/0001234"),
+    # F-prefixed (non-HK registered) -> /company/{v}
+    ("F1234567", "https://crhk.guru/company/F1234567"),
+    ("f1234567", "https://crhk.guru/company/F1234567"),  # lowercased -> uppercased
+    # Whitespace is stripped before matching
+    ("  1234567  ", "https://crhk.guru/company/1234567"),
+    (" 12345678 ", "https://crhk.guru/company/brn/12345678"),
+    # None / empty / whitespace-only -> None
+    (None, None),
+    ("", None),
+    ("   ", None),
+    # Garbage / out-of-range -> None (never a guaranteed-404 link)
+    ("123456789", None),   # 9 digits: neither BRN nor CR
+    ("F123456", None),     # F + 6 digits
+    ("F12345678", None),   # F + 8 digits
+    ("ABC", None),
+    ("12A45678", None),
+    ("HK1234567", None),
+    ("F", None),
+    # Non-string input is coerced via str()
+    (1234567, "https://crhk.guru/company/1234567"),
+    (12345678, "https://crhk.guru/company/brn/12345678"),
+]
+
+
+def run():
+    failures = []
+    for raw, expected in CASES:
+        got = crhk_company_url(raw)
+        if got != expected:
+            failures.append((raw, expected, got))
+
+    if failures:
+        print(f"FAILED {len(failures)}/{len(CASES)} cases:")
+        for raw, expected, got in failures:
+            print(f"  crhk_company_url({raw!r}) -> {got!r}, expected {expected!r}")
+        return 1
+
+    print(f"PASSED all {len(CASES)} cases")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/webbsite/__init__.py
+++ b/webbsite/__init__.py
@@ -99,6 +99,11 @@ def create_app(config_class=Config):
     app.jinja_env.globals["if_null"] = if_null
     app.jinja_env.globals["write_nav"] = write_nav
 
+    # Deep links from HK registry numbers to crhk.guru company pages.
+    from webbsite.crhk import crhk_company_url
+
+    app.jinja_env.globals["crhk_company_url"] = crhk_company_url
+
     # Register blueprints with URL prefixes matching original ASP structure
     # URLs include .asp extension for exact match with original site
     from webbsite.routes import (

--- a/webbsite/crhk.py
+++ b/webbsite/crhk.py
@@ -5,6 +5,15 @@ either the post-2023 8-digit Business Registration Number (BRN) or the pre-2023
 7-digit CR number. This module holds the single pure function that turns a raw
 registry identifier into the canonical crhk.guru URL, or ``None`` when no valid
 deep link exists (so callers never emit a guaranteed-404 link).
+
+Security invariant: templates render the raw identifier inside an inline
+``onclick`` handler (``posthog.capture(..., {ref: '<the number>'})``). Jinja
+autoescape does NOT sanitize inside inline event handlers, so that value is
+injection-safe only because the allowlist regexes below match ``[0-9Ff]``
+characters only, and callers render the anchor solely when this function
+returns non-None. Loosening a regex to admit any other character (or emitting
+the onclick for a value this function rejected) would silently reintroduce an
+XSS vector. Keep the regexes strict.
 """
 
 import re

--- a/webbsite/crhk.py
+++ b/webbsite/crhk.py
@@ -1,0 +1,38 @@
+"""Map Hong Kong company registry numbers to crhk.guru company-page URLs.
+
+crhk.guru is a Hong Kong company directory with per-company deep links keyed by
+either the post-2023 8-digit Business Registration Number (BRN) or the pre-2023
+7-digit CR number. This module holds the single pure function that turns a raw
+registry identifier into the canonical crhk.guru URL, or ``None`` when no valid
+deep link exists (so callers never emit a guaranteed-404 link).
+"""
+
+import re
+
+_BRN_RE = re.compile(r"^\d{8}$")          # post-2023 8-digit BRN
+_CRN_RE = re.compile(r"^\d{1,7}$")        # pre-2023 CR number (zero-padded to 7)
+_FOREIGN_RE = re.compile(r"^F\d{7}$")     # non-HK registered ("F" + 7 digits)
+
+
+def crhk_company_url(raw):
+    """Return the crhk.guru company-page URL for a registry number, else None.
+
+    - None / empty / whitespace-only -> None.
+    - 8 digits -> BRN deep link (``/company/brn/{v}``).
+    - 1-7 digits -> pre-2023 CR number, left-padded to 7 (``/company/{v}``);
+      unpadded numbers 404 on crhk.guru, so zfill(7) is mandatory.
+    - ``F`` + 7 digits -> non-HK registration deep link (``/company/{v}``).
+    - anything else -> None (never emit a guaranteed-404 link).
+    """
+    if raw is None:
+        return None
+    v = str(raw).strip().upper()
+    if not v:
+        return None
+    if _BRN_RE.match(v):
+        return f"https://crhk.guru/company/brn/{v}"
+    if _CRN_RE.match(v):
+        return f"https://crhk.guru/company/{v.zfill(7)}"
+    if _FOREIGN_RE.match(v):
+        return f"https://crhk.guru/company/{v}"
+    return None

--- a/webbsite/templates/dbpub/inchkcaltype.html
+++ b/webbsite/templates/dbpub/inchkcaltype.html
@@ -77,7 +77,14 @@ incorporations and name-changes.</p>
     {% for company in companies %}
     <tr>
         <td>{{ loop.index }}</td>
-        <td>{{ company.incid or '—' }}&nbsp;</td>
+        <td>
+            {%- set crhk_inc_url = crhk_company_url(company.incid) if company.incid else None -%}
+            {%- if crhk_inc_url -%}
+                <a target="_blank" rel="noopener" href="{{ crhk_inc_url }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'inchkcaltype',ref:'{{ company.incid }}'})}">{{ company.incid }}</a>
+            {%- else -%}
+                {{ company.incid or '—' }}
+            {%- endif -%}
+            &nbsp;</td>
         <td class="left"><a href="/dbpub/orgdata.asp?p={{ company.personid }}">{{ company.name1 }}{% if company.cname %}<br>{{ company.cname }}{% endif %}</a></td>
         <td class="nowrap">{{ company.incdate }}</td>
         <td class="nowrap">{{ company.disdate or '—' }}</td>

--- a/webbsite/templates/dbpub/oldest_hk_cos.html
+++ b/webbsite/templates/dbpub/oldest_hk_cos.html
@@ -19,7 +19,14 @@ some entities have an earlier, unincorporated existence.</p>
     {% for company in companies %}
     <tr>
         <td class="left"><a href="/dbpub/orgdata.asp?p={{ company.personid }}">{{ company.name }}</a></td>
-        <td>{{ company.incid }}</td>
+        <td>
+            {%- set crhk_inc_url = crhk_company_url(company.incid) if company.incid else None -%}
+            {%- if crhk_inc_url -%}
+                <a target="_blank" rel="noopener" href="{{ crhk_inc_url }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'oldest_hk_cos',ref:'{{ company.incid }}'})}">{{ company.incid }}</a>
+            {%- else -%}
+                {{ company.incid }}
+            {%- endif -%}
+        </td>
         <td>{{ company.incdate }}</td>
         <td>{% if company.disdate %}{{ company.disdate }}{% endif %}</td>
         <td>{{ company.typename }}</td>

--- a/webbsite/templates/dbpub/orgdata.html
+++ b/webbsite/templates/dbpub/orgdata.html
@@ -93,6 +93,12 @@
 				<td>
 					{% set domid = org.domid %}
 					{% if domid == 1 %}
+						{# The ref value below is interpolated into an inline onclick handler,
+						   where Jinja autoescape does NOT protect against injection. It is safe
+						   only because crhk_company_url() returned non-None, i.e. its [0-9Ff]-only
+						   allowlist matched org.incid. Never emit this onclick for a value the
+						   helper rejected, and never loosen that regex — either reintroduces XSS.
+						   Same invariant applies to the oldcrn / foreign-reg onclicks below. #}
 						{% set crhk_url = crhk_company_url(org.incid) %}
 						{% if crhk_url %}
 							<a target="_blank" rel="noopener" href="{{ crhk_url }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'orgdata',ref:'{{ org.incid }}'})}">{{ org.incid }}</a>

--- a/webbsite/templates/dbpub/orgdata.html
+++ b/webbsite/templates/dbpub/orgdata.html
@@ -93,7 +93,13 @@
 				<td>
 					{% set domid = org.domid %}
 					{% if domid == 1 %}
-						<a target="_blank" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do">{{ org.incid }}</a>
+						{% set crhk_url = crhk_company_url(org.incid) %}
+						{% if crhk_url %}
+							<a target="_blank" rel="noopener" href="{{ crhk_url }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'orgdata',ref:'{{ org.incid }}'})}">{{ org.incid }}</a>
+							<a target="_blank" rel="noopener" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do" style="font-size:smaller;">(official registry)</a>
+						{% else %}
+							<a target="_blank" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do">{{ org.incid }}</a>
+						{% endif %}
 					{% elif domid in [2, 112, 116, 311] %}
 						{% if org.ukuri %}
 							<a target="_blank" href="http://data.companieshouse.gov.uk/doc/company/{{ org.incid }}.html">{{ org.incid }}</a>
@@ -123,7 +129,14 @@
 			</tr>
 		{% endif %}
 		{% if org.oldcrn %}
-			<tr><td>HK company No. until 2023-12-27:</td><td>{{ org.oldcrn }}</td></tr>
+			<tr><td>HK company No. until 2023-12-27:</td><td>
+				{% set crhk_oldcrn_url = crhk_company_url(org.oldcrn) %}
+				{% if crhk_oldcrn_url %}
+					<a target="_blank" rel="noopener" href="{{ crhk_oldcrn_url }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'orgdata',ref:'{{ org.oldcrn }}'})}">{{ org.oldcrn }}</a>
+				{% else %}
+					{{ org.oldcrn }}
+				{% endif %}
+			</td></tr>
 		{% endif %}
 		{% if org.sfcid %}
 			<tr>
@@ -202,10 +215,12 @@
 					<td>{{ reg.friendly }}</td>
 					<td>
 						{% if reg.hostdom == 1 %}
-							{% if reg.oldcrn and reg.oldcrn != reg.regid %}
-								<a target="_blank" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do"><span class="info">{{ reg.regid }}<span>Until 2023-12-27: {{ reg.oldcrn }}</span></span></a>
+							{% set crhk_reg_url = crhk_company_url(reg.regid) %}
+							{% set reg_href = crhk_reg_url or 'https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do' %}
+							{% if crhk_reg_url %}
+								<a target="_blank" rel="noopener" href="{{ reg_href }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'orgdata',ref:'{{ reg.regid }}'})}">{% if reg.oldcrn and reg.oldcrn != reg.regid %}<span class="info">{{ reg.regid }}<span>Until 2023-12-27: {{ reg.oldcrn }}</span></span>{% else %}{{ reg.regid }}{% endif %}</a>
 							{% else %}
-								<a target="_blank" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do">{{ reg.regid }}</a>
+								<a target="_blank" href="{{ reg_href }}">{% if reg.oldcrn and reg.oldcrn != reg.regid %}<span class="info">{{ reg.regid }}<span>Until 2023-12-27: {{ reg.oldcrn }}</span></span>{% else %}{{ reg.regid }}{% endif %}</a>
 							{% endif %}
 						{% elif reg.hostdom == 2 %}
 							<a target="_blank" href="https://beta.companieshouse.gov.uk/company/{{ reg.regid }}">{{ reg.regid }}</a>


### PR DESCRIPTION
## What

Company pages currently render Hong Kong registry numbers either as plain text or, on the HK-domicile branch of `orgdata.html`, as a link to the generic ICRIS e-services **homepage** — a dead end, since ICRIS has no per-company deep URL. This replaces that with a per-company deep link to the corresponding crhk.guru company page.

## How

New module `webbsite/crhk.py` with a single pure function `crhk_company_url(raw) -> str | None`:

- `8 digits` → `https://crhk.guru/company/brn/{v}` (post-2023 BRN)
- `1-7 digits` → zero-padded to 7 → `https://crhk.guru/company/{v}` (pre-2023 CR number; unpadded numbers 404, so `zfill(7)` is mandatory)
- `F` + `7 digits` → `https://crhk.guru/company/{v}` (non-HK registered)
- `None` / empty / whitespace / anything else → `None`

The helper never emits a URL for an input that would 404, so callers fall back to their existing behaviour when it returns `None`.

Registered as a Jinja global next to the existing filter/global registrations and wired into the templates that show HK registry numbers:

- **`dbpub/orgdata.html`** — HK-domicile incorporation number deep-links to crhk.guru, with a small `(official registry)` secondary link preserving the ICRIS e-services URL; the pre-2023 `oldcrn` row and the `hostdom == 1` foreign-registration rows link via the helper. When the helper returns `None`, the exact previous ICRIS link is kept.
- **`dbpub/inchkcaltype.html`** — the incorporation-calendar `incid` (route already filters to HK domicile) becomes a link where the helper returns non-None.
- **`dbpub/oldest_hk_cos.html`** — same treatment for the HK-only "oldest companies" list, which also rendered `incid` as plain text.

All new anchors use `target="_blank" rel="noopener"` and a PostHog `crhk_outlink_click` capture mirroring the existing `_renavon_cta.html` pattern. Hrefs are clean — no UTM parameters.

## Tests

`tests/test_crhk.py` (runnable script, no network/DB) covers padding, 8-digit BRN, F-prefix, whitespace stripping, garbage, and `None`. All 22 cases pass:

```
uv run python tests/test_crhk.py
PASSED all 22 cases
```

Modified templates verified to parse and render correctly under Jinja2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)