### PR TITLE
Contextual banner: link HK company pages to their registry profile

### DIFF
--- a/tests/test_crhk_banner.py
+++ b/tests/test_crhk_banner.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Render tests for the crhk_url branch of includes/_renavon_cta.html.
+
+The contextual cross-link banner (included site-wide via base.html) grows a
+highest-priority branch: when a view passes a ``crhk_url`` template variable, the
+banner points at that company's crhk.guru registry profile instead of the generic
+dataset targets. These tests render the include through the real Flask/Jinja env
+and assert the branch selection and the injection-safe onclick contract.
+
+No database is touched — a dummy DATABASE_URL lets create_engine build lazily
+(pool_pre_ping defers the first real connection), and rendering the include never
+requests one. Run from the repo root:
+
+    uv run python tests/test_crhk_banner.py
+
+Exits non-zero if any case fails.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# create_engine needs a URL string; a bogus one is fine — it is never connected.
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost:5432/db")
+
+from flask import render_template
+
+from webbsite import create_app
+
+
+_app = create_app()
+
+
+def _render(**context):
+    with _app.test_request_context("/dbpub/orgdata.asp?p=123"):
+        return render_template("includes/_renavon_cta.html", **context)
+
+
+def run():
+    failures = []
+
+    def check(label, cond):
+        if not cond:
+            failures.append(label)
+
+    # crhk_url present -> crhk branch wins over the generic orgdata target.
+    crhk = _render(crhk_url="https://crhk.guru/company/0001234")
+    check("crhk branch: links to the profile url", "https://crhk.guru/company/0001234" in crhk)
+    check("crhk branch: fires bridge_cta_click", "bridge_cta_click" in crhk)
+    check("crhk branch: crhkguru_company dataset", "target_dataset:'crhkguru_company'" in crhk)
+    check("crhk branch: keeps banner UTM convention", "utm_campaign=bridge" in crhk)
+    check("crhk branch: registry-profile copy", "Companies Registry profile" in crhk)
+    check("crhk branch: suppresses generic archive copy", "This is a free archive" not in crhk)
+    # The onclick must not interpolate the raw url/id — only literal + location.pathname.
+    check("crhk branch: onclick uses location.pathname only", "source_path:location.pathname" in crhk)
+    check("crhk branch: onclick has no raw url", "0001234" not in crhk.split("onclick=")[1].split(">")[0])
+
+    # No crhk_url -> unchanged generic banner (orgdata maps to hkex_directors).
+    generic = _render()
+    check("generic branch: renders archive copy", "This is a free archive" in generic)
+    check("generic branch: keeps orgdata dataset target", "target_dataset:'hkex_directors'" in generic)
+    check("generic branch: no crhk dataset", "crhkguru_company" not in generic)
+
+    # Falsy crhk_url (None) -> generic branch, never a broken crhk link.
+    none_url = _render(crhk_url=None)
+    check("none crhk_url: falls back to generic", "This is a free archive" in none_url)
+    check("none crhk_url: no crhk dataset", "crhkguru_company" not in none_url)
+
+    if failures:
+        print(f"FAILED {len(failures)} checks:")
+        for label in failures:
+            print(f"  {label}")
+        return 1
+
+    print("PASSED all banner render checks")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/webbsite/routes/dbpub/statistics.py
+++ b/webbsite/routes/dbpub/statistics.py
@@ -10,6 +10,7 @@ import re
 from sqlalchemy import text
 from webbsite.db import execute_query, execute_scalar, get_db
 from webbsite.asp_helpers import get_int, get_bool, get_str, get_dbl
+from webbsite.crhk import crhk_company_url
 
 import json
 import os
@@ -8839,6 +8840,17 @@ def orgdata():
                 and dom_id in [2, 112, 116, 311],
             }
 
+    # crhk.guru registry-profile deep link for the contextual cross-link banner
+    # (webbsite/templates/includes/_renavon_cta.html). HK-domicile companies only
+    # (domid == 1); prefer the current incorporation number, fall back to the
+    # pre-2023 CR number. crhk_company_url() returns None for anything outside its
+    # strict [0-9Ff] allowlist, so the banner never emits a guaranteed-404 link.
+    crhk_url = None
+    if org_data and org_data.get("domid") == 1:
+        crhk_url = crhk_company_url(org_data.get("incid")) or crhk_company_url(
+            org_data.get("oldcrn")
+        )
+
     # Holdings section - show what this organization holds in other companies
     holdings_data = []
     holdings_tree = []
@@ -8937,6 +8949,7 @@ def orgdata():
         old_sfc_ids=old_sfc_ids,
         ever_listed=ever_listed,
         registry_links=registry_links,
+        crhk_url=crhk_url,
         websites=websites,
         nav_has_directorships=nav_has_directorships,
         nav_has_pay=nav_has_pay,

--- a/webbsite/templates/includes/_renavon_cta.html
+++ b/webbsite/templates/includes/_renavon_cta.html
@@ -17,8 +17,24 @@
   Page → dataset mapping is by blueprint (robust) with a path fallback for the
   org/people pages served out of the grab-bag dbpub_statistics blueprint. Only
   point at datasets that are visible:true on renavon.com — all targets below are
-  verified live (HTTP 200). CRHK company/director targets wait on the rebuild.
+  verified live (HTTP 200).
+
+  Highest-priority branch: a view that resolved a specific HK company to its
+  crhk.guru registry profile passes a `crhk_url` template variable (e.g.
+  orgdata.asp for domid==1). When present, the banner points at that per-company
+  profile instead of the generic dataset targets. crhk_url is None unless the
+  view built it via crhk_company_url() (strict [0-9Ff] allowlist), so nothing
+  untrusted reaches the href here.
 #}
+{%- if crhk_url is defined and crhk_url -%}
+<div id="renavon-banner" style="background:#1a1a2e;border-bottom:2px solid #0891b2;padding:8px 16px;text-align:center;font-family:Arial,sans-serif;font-size:13px;">
+    <span style="color:#e2e8f0;">Full Companies Registry profile for this company &mdash; free on CRHK&nbsp;Guru</span>
+    <a href="{{ crhk_url }}?utm_source=webbsite&amp;utm_medium=cta&amp;utm_campaign=bridge&amp;ref=webbsite&amp;ref_path={{ request.path | urlencode }}"
+       target="_blank" rel="noopener"
+       onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:'crhkguru_company',source_path:location.pathname})}"
+       style="color:#22d3ee;text-decoration:underline;font-weight:bold;margin-left:6px;">view on CRHK&nbsp;Guru &rarr;</a>
+</div>
+{%- else -%}
 {%- set _bp = request.blueprint or '' -%}
 {%- set _path = request.path | lower -%}
 {%- if _bp == 'dbpub_sfc' or 'sfc' in _path -%}
@@ -46,3 +62,4 @@
        onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:'{{ _ds }}',source_path:location.pathname})}"
        style="color:#22d3ee;text-decoration:underline;font-weight:bold;margin-left:6px;">{{ _cta }} &rarr;</a>
 </div>
+{%- endif -%}


### PR DESCRIPTION
## What

The site-wide contextual cross-link banner (`webbsite/templates/includes/_renavon_cta.html`, included via `base.html`) previously only offered generic dataset targets by page type. This adds a **highest-priority branch**: when the rendering view sets a `crhk_url` template variable, the banner links to that specific company's registry profile on crhk.guru instead of the generic dataset.

## How

- **`routes/dbpub/statistics.py::orgdata()`** computes `crhk_url` for HK-domicile companies only (`domid == 1`) as `crhk_company_url(incid) or crhk_company_url(oldcrn)`, and passes it into the template context. It reuses the existing `webbsite/crhk.py` helper (merged in #18), whose strict `[0-9Ff]` allowlist means the banner never emits a guaranteed-404 link and no untrusted value reaches the `href`/`onclick`.
- **`_renavon_cta.html`** gains the `crhk_url` branch, following the file's existing structure. It keeps the banner's UTM-parameter convention and fires the existing `bridge_cta_click` PostHog event with `target_dataset:'crhkguru_company'`. The `onclick` interpolates only literals and `location.pathname` (no raw org value), mirroring the quoting fixed in 87d9c7f. Every other page type renders the generic banner exactly as before.
- **`tests/test_crhk_banner.py`** — standalone render tests (same runner style as `tests/test_crhk.py`, no DB/network) asserting branch selection, fallback to the generic banner when `crhk_url` is absent/None, and the injection-safe onclick contract.

## Testing

```
$ uv run python tests/test_crhk_banner.py
PASSED all banner render checks
$ uv run python tests/test_crhk.py
PASSED all 22 cases
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)