### PR TITLE
Disable preload_app: HUP auto-deploy never reloaded preloaded code

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -134,3 +134,12 @@ default to `webbsite.renavon.com`. Moving domains needs **no code change**:
 | `sudo -u postgres psql enigma` | DB shell |
 | `ufw status verbose` | Firewall rules |
 | `vmtouch /var/lib/postgresql/17/main` | Page-cache residency of the DB |
+
+### Deploy-contract gotcha: preload_app vs `systemctl reload` (2026-07-16 incident)
+Gunicorn does **not** reload application code on SIGHUP when `preload_app = True` —
+workers are recycled from the stale master image while Jinja reads new templates
+from disk. A deploy whose templates call newly-added Python (a Jinja global,
+filter, or context key) then 500s until a full `systemctl restart`. This took
+orgdata.asp down on 2026-07-16 (#20 reverted it). `gunicorn.conf.py` therefore
+pins `preload_app = False`; if preload is ever re-enabled, the site-deploy step
+for this site must switch from `reload` to `restart` first.

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -42,10 +42,17 @@ group = None
 tmp_upload_dir = None
 worker_tmp_dir = "/dev/shm"  # RAM-backed heartbeat; prevents false worker kills on overlay FS
 
-# Preload app in master process: workers inherit compiled bytecode via fork (near-instant
-# restarts instead of re-importing 25K+ lines on 0.5 CPU). post_fork disposes inherited
-# DB connections so each worker creates its own fresh pool.
-preload_app = True
+# preload_app MUST stay False: the auto-deploy (site-deploy timer) applies code
+# changes with `systemctl reload` = SIGHUP, and gunicorn does NOT reload
+# application code on HUP when the app is preloaded — recycled workers fork
+# from the stale master image while Jinja reads the NEW templates from disk.
+# That skew 500'd every orgdata.asp request on 2026-07-16 (template called a
+# Jinja global the old code had never registered; fixed by revert #20). The
+# preload was a Render-era optimization (fast forks on 0.5 CPU); on the droplet
+# the per-worker re-import cost is fine, and HUP now reloads config + code +
+# templates atomically. If preload is ever re-enabled, the deploy contract must
+# change to `systemctl restart` first.
+preload_app = False
 
 
 def on_starting(server):
@@ -66,10 +73,11 @@ def when_ready(server):
 def post_fork(server, worker):
     """Dispose inherited DB connections after fork.
 
-    With preload_app=True, the master creates the SQLAlchemy engine during app
-    loading.  After fork, children must NOT share the parent's socket connections.
-    engine.dispose() closes all pooled connections; new ones are created on demand
-    in each worker with their own SSL state.
+    Defensive holdover from the preload_app=True era (a master-created
+    SQLAlchemy engine must not share sockets across forks). With preload off
+    the engine is created per-worker and this is a guarded no-op — kept
+    because it is harmless and load-bearing again the moment anyone
+    re-enables preload.
     """
     try:
         from webbsite.db import _engine


### PR DESCRIPTION
Root cause of today's orgdata.asp 500s (reverted in #20): the auto-deploy applies code via `systemctl reload` (SIGHUP), and gunicorn documents that with `preload_app = True` a HUP recycles workers **without reloading application code**. Fresh workers therefore rendered the newly-pulled templates against the old Python image — the template called a Jinja global the running code had never registered, and every render raised. The revert healed it by putting templates back in sync with the stale code, which is also why the code change itself tested clean locally.

Fix: pin `preload_app = False` (Render-era 0.5-CPU optimization, no longer needed on the droplet), so a HUP reloads config + code + templates atomically. `post_fork` engine disposal is kept as a guarded no-op with an explanatory docstring. deploy/README documents the contract.

After this deploys, #18/#19 can be re-landed unchanged — the code was never at fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)