### PR TITLE
Reland: crhk.guru company links + contextual banner (#18/#19)

### DIFF
--- a/tests/test_crhk.py
+++ b/tests/test_crhk.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Unit tests for webbsite.crhk.crhk_company_url.
+
+Pure-function tests — no Flask app, no database, no network. Run from the repo
+root so ``webbsite`` is importable:
+
+    uv run python tests/test_crhk.py
+
+Exits non-zero if any case fails.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from webbsite.crhk import crhk_company_url
+
+# (input, expected) pairs covering every branch of the helper.
+CASES = [
+    # 8-digit BRN -> /company/brn/{v}
+    ("12345678", "https://crhk.guru/company/brn/12345678"),
+    ("00000001", "https://crhk.guru/company/brn/00000001"),
+    # 1-7 digit CR number -> zero-padded to 7 -> /company/{v}
+    ("1", "https://crhk.guru/company/0000001"),
+    ("123", "https://crhk.guru/company/0000123"),
+    ("1234567", "https://crhk.guru/company/1234567"),
+    ("0001234", "https://crhk.guru/company/0001234"),
+    # F-prefixed (non-HK registered) -> /company/{v}
+    ("F1234567", "https://crhk.guru/company/F1234567"),
+    ("f1234567", "https://crhk.guru/company/F1234567"),  # lowercased -> uppercased
+    # Whitespace is stripped before matching
+    ("  1234567  ", "https://crhk.guru/company/1234567"),
+    (" 12345678 ", "https://crhk.guru/company/brn/12345678"),
+    # None / empty / whitespace-only -> None
+    (None, None),
+    ("", None),
+    ("   ", None),
+    # Garbage / out-of-range -> None (never a guaranteed-404 link)
+    ("123456789", None),   # 9 digits: neither BRN nor CR
+    ("F123456", None),     # F + 6 digits
+    ("F12345678", None),   # F + 8 digits
+    ("ABC", None),
+    ("12A45678", None),
+    ("HK1234567", None),
+    ("F", None),
+    # Non-string input is coerced via str()
+    (1234567, "https://crhk.guru/company/1234567"),
+    (12345678, "https://crhk.guru/company/brn/12345678"),
+]
+
+
+def run():
+    failures = []
+    for raw, expected in CASES:
+        got = crhk_company_url(raw)
+        if got != expected:
+            failures.append((raw, expected, got))
+
+    if failures:
+        print(f"FAILED {len(failures)}/{len(CASES)} cases:")
+        for raw, expected, got in failures:
+            print(f"  crhk_company_url({raw!r}) -> {got!r}, expected {expected!r}")
+        return 1
+
+    print(f"PASSED all {len(CASES)} cases")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/tests/test_crhk_banner.py
+++ b/tests/test_crhk_banner.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Render tests for the crhk_url branch of includes/_renavon_cta.html.
+
+The contextual cross-link banner (included site-wide via base.html) grows a
+highest-priority branch: when a view passes a ``crhk_url`` template variable, the
+banner points at that company's crhk.guru registry profile instead of the generic
+dataset targets. These tests render the include through the real Flask/Jinja env
+and assert the branch selection and the injection-safe onclick contract.
+
+No database is touched — a dummy DATABASE_URL lets create_engine build lazily
+(pool_pre_ping defers the first real connection), and rendering the include never
+requests one. Run from the repo root:
+
+    uv run python tests/test_crhk_banner.py
+
+Exits non-zero if any case fails.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# create_engine needs a URL string; a bogus one is fine — it is never connected.
+os.environ.setdefault("DATABASE_URL", "postgresql://u:p@localhost:5432/db")
+
+from flask import render_template
+
+from webbsite import create_app
+
+
+_app = create_app()
+
+
+def _render(**context):
+    with _app.test_request_context("/dbpub/orgdata.asp?p=123"):
+        return render_template("includes/_renavon_cta.html", **context)
+
+
+def run():
+    failures = []
+
+    def check(label, cond):
+        if not cond:
+            failures.append(label)
+
+    # crhk_url present -> crhk branch wins over the generic orgdata target.
+    crhk = _render(crhk_url="https://crhk.guru/company/0001234")
+    check("crhk branch: links to the profile url", "https://crhk.guru/company/0001234" in crhk)
+    check("crhk branch: fires bridge_cta_click", "bridge_cta_click" in crhk)
+    check("crhk branch: crhkguru_company dataset", "target_dataset:'crhkguru_company'" in crhk)
+    check("crhk branch: keeps banner UTM convention", "utm_campaign=bridge" in crhk)
+    check("crhk branch: registry-profile copy", "Companies Registry profile" in crhk)
+    check("crhk branch: suppresses generic archive copy", "This is a free archive" not in crhk)
+    # The onclick must not interpolate the raw url/id — only literal + location.pathname.
+    check("crhk branch: onclick uses location.pathname only", "source_path:location.pathname" in crhk)
+    check("crhk branch: onclick has no raw url", "0001234" not in crhk.split("onclick=")[1].split(">")[0])
+
+    # No crhk_url -> unchanged generic banner (orgdata maps to hkex_directors).
+    generic = _render()
+    check("generic branch: renders archive copy", "This is a free archive" in generic)
+    check("generic branch: keeps orgdata dataset target", "target_dataset:'hkex_directors'" in generic)
+    check("generic branch: no crhk dataset", "crhkguru_company" not in generic)
+
+    # Falsy crhk_url (None) -> generic branch, never a broken crhk link.
+    none_url = _render(crhk_url=None)
+    check("none crhk_url: falls back to generic", "This is a free archive" in none_url)
+    check("none crhk_url: no crhk dataset", "crhkguru_company" not in none_url)
+
+    if failures:
+        print(f"FAILED {len(failures)} checks:")
+        for label in failures:
+            print(f"  {label}")
+        return 1
+
+    print("PASSED all banner render checks")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/webbsite/__init__.py
+++ b/webbsite/__init__.py
@@ -99,6 +99,11 @@ def create_app(config_class=Config):
     app.jinja_env.globals["if_null"] = if_null
     app.jinja_env.globals["write_nav"] = write_nav
 
+    # Deep links from HK registry numbers to crhk.guru company pages.
+    from webbsite.crhk import crhk_company_url
+
+    app.jinja_env.globals["crhk_company_url"] = crhk_company_url
+
     # Register blueprints with URL prefixes matching original ASP structure
     # URLs include .asp extension for exact match with original site
     from webbsite.routes import (

--- a/webbsite/crhk.py
+++ b/webbsite/crhk.py
@@ -1,0 +1,47 @@
+"""Map Hong Kong company registry numbers to crhk.guru company-page URLs.
+
+crhk.guru is a Hong Kong company directory with per-company deep links keyed by
+either the post-2023 8-digit Business Registration Number (BRN) or the pre-2023
+7-digit CR number. This module holds the single pure function that turns a raw
+registry identifier into the canonical crhk.guru URL, or ``None`` when no valid
+deep link exists (so callers never emit a guaranteed-404 link).
+
+Security invariant: templates render the raw identifier inside an inline
+``onclick`` handler (``posthog.capture(..., {ref: '<the number>'})``). Jinja
+autoescape does NOT sanitize inside inline event handlers, so that value is
+injection-safe only because the allowlist regexes below match ``[0-9Ff]``
+characters only, and callers render the anchor solely when this function
+returns non-None. Loosening a regex to admit any other character (or emitting
+the onclick for a value this function rejected) would silently reintroduce an
+XSS vector. Keep the regexes strict.
+"""
+
+import re
+
+_BRN_RE = re.compile(r"^\d{8}$")          # post-2023 8-digit BRN
+_CRN_RE = re.compile(r"^\d{1,7}$")        # pre-2023 CR number (zero-padded to 7)
+_FOREIGN_RE = re.compile(r"^F\d{7}$")     # non-HK registered ("F" + 7 digits)
+
+
+def crhk_company_url(raw):
+    """Return the crhk.guru company-page URL for a registry number, else None.
+
+    - None / empty / whitespace-only -> None.
+    - 8 digits -> BRN deep link (``/company/brn/{v}``).
+    - 1-7 digits -> pre-2023 CR number, left-padded to 7 (``/company/{v}``);
+      unpadded numbers 404 on crhk.guru, so zfill(7) is mandatory.
+    - ``F`` + 7 digits -> non-HK registration deep link (``/company/{v}``).
+    - anything else -> None (never emit a guaranteed-404 link).
+    """
+    if raw is None:
+        return None
+    v = str(raw).strip().upper()
+    if not v:
+        return None
+    if _BRN_RE.match(v):
+        return f"https://crhk.guru/company/brn/{v}"
+    if _CRN_RE.match(v):
+        return f"https://crhk.guru/company/{v.zfill(7)}"
+    if _FOREIGN_RE.match(v):
+        return f"https://crhk.guru/company/{v}"
+    return None

--- a/webbsite/routes/dbpub/statistics.py
+++ b/webbsite/routes/dbpub/statistics.py
@@ -10,6 +10,7 @@ import re
 from sqlalchemy import text
 from webbsite.db import execute_query, execute_scalar, get_db
 from webbsite.asp_helpers import get_int, get_bool, get_str, get_dbl
+from webbsite.crhk import crhk_company_url
 
 import json
 import os
@@ -8839,6 +8840,17 @@ def orgdata():
                 and dom_id in [2, 112, 116, 311],
             }
 
+    # crhk.guru registry-profile deep link for the contextual cross-link banner
+    # (webbsite/templates/includes/_renavon_cta.html). HK-domicile companies only
+    # (domid == 1); prefer the current incorporation number, fall back to the
+    # pre-2023 CR number. crhk_company_url() returns None for anything outside its
+    # strict [0-9Ff] allowlist, so the banner never emits a guaranteed-404 link.
+    crhk_url = None
+    if org_data and org_data.get("domid") == 1:
+        crhk_url = crhk_company_url(org_data.get("incid")) or crhk_company_url(
+            org_data.get("oldcrn")
+        )
+
     # Holdings section - show what this organization holds in other companies
     holdings_data = []
     holdings_tree = []
@@ -8937,6 +8949,7 @@ def orgdata():
         old_sfc_ids=old_sfc_ids,
         ever_listed=ever_listed,
         registry_links=registry_links,
+        crhk_url=crhk_url,
         websites=websites,
         nav_has_directorships=nav_has_directorships,
         nav_has_pay=nav_has_pay,

--- a/webbsite/templates/dbpub/inchkcaltype.html
+++ b/webbsite/templates/dbpub/inchkcaltype.html
@@ -77,7 +77,14 @@ incorporations and name-changes.</p>
     {% for company in companies %}
     <tr>
         <td>{{ loop.index }}</td>
-        <td>{{ company.incid or '—' }}&nbsp;</td>
+        <td>
+            {%- set crhk_inc_url = crhk_company_url(company.incid) if company.incid else None -%}
+            {%- if crhk_inc_url -%}
+                <a target="_blank" rel="noopener" href="{{ crhk_inc_url }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'inchkcaltype',ref:'{{ company.incid }}'})}">{{ company.incid }}</a>
+            {%- else -%}
+                {{ company.incid or '—' }}
+            {%- endif -%}
+            &nbsp;</td>
         <td class="left"><a href="/dbpub/orgdata.asp?p={{ company.personid }}">{{ company.name1 }}{% if company.cname %}<br>{{ company.cname }}{% endif %}</a></td>
         <td class="nowrap">{{ company.incdate }}</td>
         <td class="nowrap">{{ company.disdate or '—' }}</td>

--- a/webbsite/templates/dbpub/oldest_hk_cos.html
+++ b/webbsite/templates/dbpub/oldest_hk_cos.html
@@ -19,7 +19,14 @@ some entities have an earlier, unincorporated existence.</p>
     {% for company in companies %}
     <tr>
         <td class="left"><a href="/dbpub/orgdata.asp?p={{ company.personid }}">{{ company.name }}</a></td>
-        <td>{{ company.incid }}</td>
+        <td>
+            {%- set crhk_inc_url = crhk_company_url(company.incid) if company.incid else None -%}
+            {%- if crhk_inc_url -%}
+                <a target="_blank" rel="noopener" href="{{ crhk_inc_url }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'oldest_hk_cos',ref:'{{ company.incid }}'})}">{{ company.incid }}</a>
+            {%- else -%}
+                {{ company.incid }}
+            {%- endif -%}
+        </td>
         <td>{{ company.incdate }}</td>
         <td>{% if company.disdate %}{{ company.disdate }}{% endif %}</td>
         <td>{{ company.typename }}</td>

--- a/webbsite/templates/dbpub/orgdata.html
+++ b/webbsite/templates/dbpub/orgdata.html
@@ -93,7 +93,19 @@
 				<td>
 					{% set domid = org.domid %}
 					{% if domid == 1 %}
-						<a target="_blank" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do">{{ org.incid }}</a>
+						{# The ref value below is interpolated into an inline onclick handler,
+						   where Jinja autoescape does NOT protect against injection. It is safe
+						   only because crhk_company_url() returned non-None, i.e. its [0-9Ff]-only
+						   allowlist matched org.incid. Never emit this onclick for a value the
+						   helper rejected, and never loosen that regex — either reintroduces XSS.
+						   Same invariant applies to the oldcrn / foreign-reg onclicks below. #}
+						{% set crhk_url = crhk_company_url(org.incid) %}
+						{% if crhk_url %}
+							<a target="_blank" rel="noopener" href="{{ crhk_url }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'orgdata',ref:'{{ org.incid }}'})}">{{ org.incid }}</a>
+							<a target="_blank" rel="noopener" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do" style="font-size:smaller;">(official registry)</a>
+						{% else %}
+							<a target="_blank" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do">{{ org.incid }}</a>
+						{% endif %}
 					{% elif domid in [2, 112, 116, 311] %}
 						{% if org.ukuri %}
 							<a target="_blank" href="http://data.companieshouse.gov.uk/doc/company/{{ org.incid }}.html">{{ org.incid }}</a>
@@ -123,7 +135,14 @@
 			</tr>
 		{% endif %}
 		{% if org.oldcrn %}
-			<tr><td>HK company No. until 2023-12-27:</td><td>{{ org.oldcrn }}</td></tr>
+			<tr><td>HK company No. until 2023-12-27:</td><td>
+				{% set crhk_oldcrn_url = crhk_company_url(org.oldcrn) %}
+				{% if crhk_oldcrn_url %}
+					<a target="_blank" rel="noopener" href="{{ crhk_oldcrn_url }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'orgdata',ref:'{{ org.oldcrn }}'})}">{{ org.oldcrn }}</a>
+				{% else %}
+					{{ org.oldcrn }}
+				{% endif %}
+			</td></tr>
 		{% endif %}
 		{% if org.sfcid %}
 			<tr>
@@ -202,10 +221,12 @@
 					<td>{{ reg.friendly }}</td>
 					<td>
 						{% if reg.hostdom == 1 %}
-							{% if reg.oldcrn and reg.oldcrn != reg.regid %}
-								<a target="_blank" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do"><span class="info">{{ reg.regid }}<span>Until 2023-12-27: {{ reg.oldcrn }}</span></span></a>
+							{% set crhk_reg_url = crhk_company_url(reg.regid) %}
+							{% set reg_href = crhk_reg_url or 'https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do' %}
+							{% if crhk_reg_url %}
+								<a target="_blank" rel="noopener" href="{{ reg_href }}" onclick="if(window.posthog){posthog.capture('crhk_outlink_click',{source:'orgdata',ref:'{{ reg.regid }}'})}">{% if reg.oldcrn and reg.oldcrn != reg.regid %}<span class="info">{{ reg.regid }}<span>Until 2023-12-27: {{ reg.oldcrn }}</span></span>{% else %}{{ reg.regid }}{% endif %}</a>
 							{% else %}
-								<a target="_blank" href="https://www.e-services.cr.gov.hk/ICRIS3EP/system/home.do">{{ reg.regid }}</a>
+								<a target="_blank" href="{{ reg_href }}">{% if reg.oldcrn and reg.oldcrn != reg.regid %}<span class="info">{{ reg.regid }}<span>Until 2023-12-27: {{ reg.oldcrn }}</span></span>{% else %}{{ reg.regid }}{% endif %}</a>
 							{% endif %}
 						{% elif reg.hostdom == 2 %}
 							<a target="_blank" href="https://beta.companieshouse.gov.uk/company/{{ reg.regid }}">{{ reg.regid }}</a>

--- a/webbsite/templates/includes/_renavon_cta.html
+++ b/webbsite/templates/includes/_renavon_cta.html
@@ -17,8 +17,24 @@
   Page → dataset mapping is by blueprint (robust) with a path fallback for the
   org/people pages served out of the grab-bag dbpub_statistics blueprint. Only
   point at datasets that are visible:true on renavon.com — all targets below are
-  verified live (HTTP 200). CRHK company/director targets wait on the rebuild.
+  verified live (HTTP 200).
+
+  Highest-priority branch: a view that resolved a specific HK company to its
+  crhk.guru registry profile passes a `crhk_url` template variable (e.g.
+  orgdata.asp for domid==1). When present, the banner points at that per-company
+  profile instead of the generic dataset targets. crhk_url is None unless the
+  view built it via crhk_company_url() (strict [0-9Ff] allowlist), so nothing
+  untrusted reaches the href here.
 #}
+{%- if crhk_url is defined and crhk_url -%}
+<div id="renavon-banner" style="background:#1a1a2e;border-bottom:2px solid #0891b2;padding:8px 16px;text-align:center;font-family:Arial,sans-serif;font-size:13px;">
+    <span style="color:#e2e8f0;">Full Companies Registry profile for this company &mdash; free on CRHK&nbsp;Guru</span>
+    <a href="{{ crhk_url }}?utm_source=webbsite&amp;utm_medium=cta&amp;utm_campaign=bridge&amp;ref=webbsite&amp;ref_path={{ request.path | urlencode }}"
+       target="_blank" rel="noopener"
+       onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:'crhkguru_company',source_path:location.pathname})}"
+       style="color:#22d3ee;text-decoration:underline;font-weight:bold;margin-left:6px;">view on CRHK&nbsp;Guru &rarr;</a>
+</div>
+{%- else -%}
 {%- set _bp = request.blueprint or '' -%}
 {%- set _path = request.path | lower -%}
 {%- if _bp == 'dbpub_sfc' or 'sfc' in _path -%}
@@ -46,3 +62,4 @@
        onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:'{{ _ds }}',source_path:location.pathname})}"
        style="color:#22d3ee;text-decoration:underline;font-weight:bold;margin-left:6px;">{{ _cta }} &rarr;</a>
 </div>
+{%- endif -%}


### PR DESCRIPTION
Reverts the emergency revert #20. Root cause of the 500s was the preload_app/SIGHUP deploy skew fixed in #21 — with preload disabled, code and templates now deploy atomically, and the relanded revision rendered clean in offline testing. Content is byte-identical to the previously merged #18 + #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)