### PR TITLE
feat(freshness): TTL ladder rework + un-hardcode the 2025-10-10 freeze

### DIFF
--- a/tests/test_cache_headers.py
+++ b/tests/test_cache_headers.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Runnable checks for the freshness rework (no DB, no pytest).
+
+Covers the load-bearing, DB-free logic:
+  1. the data-page TTL ladder (_data_page_ttls / _asof_from_args),
+  2. the enigma.log watermark helper's fallback path, and
+  3. a grep gate proving the hardcoded freeze constants are gone.
+
+Run:  uv run python tests/test_cache_headers.py
+"""
+
+import os
+import re
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from webbsite import _asof_from_args, _data_page_ttls, _TTL_DEEP, _TTL_LATEST, _TTL_SETTLED
+from webbsite import watermarks
+
+_failures: list[str] = []
+
+
+def check(name, got, want):
+    if got != want:
+        _failures.append(f"{name}: got {got!r}, want {want!r}")
+    else:
+        print(f"  ok  {name}")
+
+
+def iso(days_ago):
+    return (date.today() - timedelta(days=days_ago)).isoformat()
+
+
+def test_ttl_ladder():
+    print("== TTL ladder ==")
+    check("no date -> latest", _data_page_ttls({}), _TTL_LATEST)
+    check("d1 alone (open range) -> latest", _data_page_ttls({"d1": iso(400)}), _TTL_LATEST)
+    check("recent d -> latest", _data_page_ttls({"d": iso(3)}), _TTL_LATEST)
+    check("14d-boundary d -> latest", _data_page_ttls({"d": iso(14)}), _TTL_LATEST)
+    check("30d-old d -> settled", _data_page_ttls({"d": iso(30)}), _TTL_SETTLED)
+    check("400d-old d -> deep", _data_page_ttls({"d": iso(400)}), _TTL_DEEP)
+    check("d2 pins over d", _data_page_ttls({"d": iso(3), "d2": iso(400)}), _TTL_DEEP)
+    check("malformed d -> latest", _data_page_ttls({"d": "not-a-date"}), _TTL_LATEST)
+    check("asof reads d2 then d", _asof_from_args({"d2": iso(30)}), date.today() - timedelta(days=30))
+    check("asof None when no date", _asof_from_args({"d1": iso(30)}), None)
+
+
+def test_watermark_fallback():
+    print("== watermark fallback (no DB) ==")
+    # No app context -> the query fails -> the frozen-archive fallback is returned.
+    check("ccass_done fallback", watermarks.ccass_done(), "2025-10-17")
+    check("quotes_end fallback = min(MB,GEM)", watermarks.quotes_end(), "2025-10-10")
+    check("data_end is a date", watermarks.data_end(), date(2025, 10, 10))
+
+
+def test_freeze_constants_gone():
+    print("== grep gate: freeze constants removed ==")
+    pkg = Path(__file__).resolve().parent.parent / "webbsite"
+    banned = {
+        "2025-10-17": [],
+        "DATA_END": [],
+        "DATA_FREEZE": [],
+    }
+    for py in pkg.rglob("*.py"):
+        # watermarks.py is the ONE sanctioned home of the frozen-archive fallback.
+        if py.name == "watermarks.py":
+            continue
+        text = py.read_text(encoding="utf-8")
+        for token in banned:
+            if re.search(re.escape(token), text):
+                banned[token].append(str(py.relative_to(pkg.parent)))
+    for token, hits in banned.items():
+        check(f"no `{token}` in webbsite/", hits, [])
+
+
+if __name__ == "__main__":
+    test_ttl_ladder()
+    test_watermark_fallback()
+    test_freeze_constants_gone()
+    if _failures:
+        print("\nFAILURES:")
+        for f in _failures:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("\nAll cache-header / freshness checks passed.")

--- a/webbsite/__init__.py
+++ b/webbsite/__init__.py
@@ -5,11 +5,48 @@ Direct port from Classic ASP to Flask/Jinja
 
 from flask import Flask, render_template, redirect, request, g, Response
 from flask_compress import Compress
+from datetime import datetime, date as _date
 import time
 import logging
 from .config import Config
 
 logger = logging.getLogger(__name__)
+
+# Edge/browser cache TTL ladder for data pages (seconds). The archive is refreshed
+# daily now (webbsite/watermarks.py + deploy/README "Daily data refresh"), so a page
+# that pins its upper bound to an OLD date is effectively immutable and caches long,
+# while a "latest" view (no end-date, or a recent one) caches briefly so a refresh
+# shows up within hours WITHOUT the loader ever purging Cloudflare.
+_TTL_LATEST = (3600, 14400)      # 1h browser / 4h edge  — latest views / recent dates
+_TTL_SETTLED = (86400, 2592000)  # 1d / 30d              — snapshots older than ~2 weeks
+_TTL_DEEP = (604800, 31536000)   # 7d / 1y               — snapshots older than a year
+
+
+def _asof_from_args(args):
+    """The as-of date a data page pins its UPPER bound to, or None for a "latest"
+    view. ``d2`` (range end) then ``d`` (snapshot) pin the page; ``d1`` alone (open
+    range) means "to latest" and stays fresh. Malformed/absent -> None (fresh)."""
+    for p in ("d2", "d"):
+        v = args.get(p, "")
+        if len(v) == 10:
+            try:
+                return datetime.strptime(v, "%Y-%m-%d").date()
+            except ValueError:
+                pass
+    return None
+
+
+def _data_page_ttls(args):
+    """(browser_ttl, edge_ttl) for a data page, by the age of the date it pins."""
+    asof = _asof_from_args(args)
+    if asof is None:
+        return _TTL_LATEST
+    age = (_date.today() - asof).days
+    if age > 365:
+        return _TTL_DEEP
+    if age > 14:
+        return _TTL_SETTLED
+    return _TTL_LATEST
 
 # Aggressive SEO/AI crawlers blocked at the origin (mirror of Cloudflare WAF rule).
 # Defense-in-depth in case direct *.onrender.com URL is hit.
@@ -218,10 +255,15 @@ def create_app(config_class=Config):
             response.headers.setdefault("Cache-Control", "no-store")
             return response
 
-        # CSV exports: 1 day browser, 1 day edge
+        # CSV exports. A CSV that pins an old end-date is settled history (1d/1d);
+        # a "latest" CSV (no end-date, or a recent one) tracks the daily refresh (1h/4h).
         if path.endswith("CSV.asp"):
-            response.headers.setdefault("Cache-Control", "public, max-age=86400")
-            response.headers["CDN-Cache-Control"] = "max-age=86400"
+            if _asof_from_args(request.args) and _data_page_ttls(request.args) != _TTL_LATEST:
+                response.headers.setdefault("Cache-Control", "public, max-age=86400")
+                response.headers["CDN-Cache-Control"] = "max-age=86400"
+            else:
+                response.headers.setdefault("Cache-Control", "public, max-age=3600")
+                response.headers["CDN-Cache-Control"] = "max-age=14400"
             return response
 
         # Articles never change once published: 7 day browser, 1 year edge
@@ -236,23 +278,14 @@ def create_app(config_class=Config):
             response.headers["CDN-Cache-Control"] = "max-age=604800"
             return response
 
-        # Data pages (.asp or directory index). The archive is frozen (data ends
-        # 2025-10-10), so every page is immutable. Cache hard at the edge so
-        # crawlers/users hit warm Cloudflare instead of a ~1s origin render on
-        # every unique ?p=<id>; a ?d= older than a year gets an even longer TTL.
+        # Data pages (.asp or directory index). The archive is refreshed daily, so a
+        # page's TTL follows the age of the date it pins: a "latest" view (no end-date
+        # or a recent one) caches only ~4h at the edge so a refresh shows up quickly
+        # without a purge, while a page pinned to old history caches 30d/1y. A
+        # high-cardinality crawler page with no ?d= (orgdata.asp?p=…) renders refreshed
+        # data, so the shorter latest-tier TTL is correct.
         if path.endswith(".asp") or path.endswith("/"):
-            d_param = request.args.get("d", "")
-            ttl_browser = 86400      # 1 day
-            ttl_edge = 2592000       # 30 days
-            if d_param and len(d_param) == 10:
-                try:
-                    from datetime import datetime, date as _date
-                    parsed = datetime.strptime(d_param, "%Y-%m-%d").date()
-                    if (_date.today() - parsed).days > 365:
-                        ttl_browser = 604800       # 7 days
-                        ttl_edge = 31536000        # 1 year
-                except ValueError:
-                    pass
+            ttl_browser, ttl_edge = _data_page_ttls(request.args)
             response.headers.setdefault("Cache-Control", f"public, max-age={ttl_browser}")
             response.headers["CDN-Cache-Control"] = f"max-age={ttl_edge}"
         return response
@@ -264,6 +297,16 @@ def create_app(config_class=Config):
     def _inject_now():
         from datetime import date as _date
         return {"now": _date.today()}
+
+    # Expose the live data watermarks to every template (the CTA banner says how
+    # current the archive is). Best-effort — never break rendering on a DB hiccup.
+    @app.context_processor
+    def _inject_data_asof():
+        from webbsite import watermarks
+        try:
+            return {"data_asof": watermarks.quotes_end(), "ccass_asof": watermarks.ccass_done()}
+        except Exception:
+            return {"data_asof": None, "ccass_asof": None}
 
     # Expose canonical_query() to templates (base.html builds rel=canonical from it).
     from webbsite.asp_helpers import canonical_query

--- a/webbsite/routes/ccass.py
+++ b/webbsite/routes/ccass.py
@@ -7,6 +7,7 @@ from flask import Blueprint, render_template, request, Response
 from datetime import datetime, date
 from webbsite.db import execute_query
 from webbsite.asp_helpers import get_int, get_str, get_bool, ms_date
+from webbsite import watermarks
 
 bp = Blueprint("ccass", __name__)
 
@@ -63,19 +64,7 @@ def bigchanges():
 
     # Get latest CCASS date if none specified
     if not d:
-        try:
-            result = execute_query(
-                "SELECT val FROM enigma.log WHERE name = 'CCASSdateDone'"
-            )
-            if result and result[0]["val"]:
-                d = result[0]["val"]
-            else:
-                d = "2025-10-17"  # Fallback if log entry doesn't exist
-        except Exception as ex:
-            from flask import current_app
-
-            current_app.logger.warning(f"Could not get CCASSdateDone from log: {ex}")
-            d = "2025-10-17"  # Fallback date
+        d = watermarks.ccass_done()
 
     # Get max settlement date <= requested date
     try:
@@ -166,19 +155,7 @@ def cconc():
 
     # Get latest CCASS date if none specified
     if not d:
-        try:
-            result = execute_query(
-                "SELECT val FROM enigma.log WHERE name = 'CCASSdateDone'"
-            )
-            if result and result[0]["val"]:
-                d = result[0]["val"]
-            else:
-                d = "2025-10-17"  # Fallback if log entry doesn't exist
-        except Exception as ex:
-            from flask import current_app
-
-            current_app.logger.warning(f"Could not get CCASSdateDone from log: {ex}")
-            d = "2025-10-17"  # Fallback date
+        d = watermarks.ccass_done()
     else:
         # If date is specified but no data exists for that date,
         # adjust to the last date with data (ASP behavior for holidays)
@@ -280,19 +257,20 @@ def ipstakes():
     sort_param = request.args.get("sort", "ipsdn")
     d = request.args.get("d", "")
 
-    # Get latest CCASS date if not specified
+    # Get latest CCASS date if not specified (the live MAX tracks the daily refresh;
+    # the watermark is the fallback when the query fails or dailylog is empty).
     if not d:
         try:
             result = execute_query("SELECT MAX(atDate) as max_date FROM ccass.dailylog")
             if result and result[0]['max_date']:
                 d = ms_date(result[0]['max_date'])
             else:
-                d = "2025-10-17"  # Fallback
+                d = watermarks.ccass_done()
         except Exception as ex:
             from flask import current_app
 
             current_app.logger.error(f"Error getting latest CCASS date: {ex}")
-            d = "2025-10-17"
+            d = watermarks.ccass_done()
 
     # Get max settlement date <= requested date
     try:
@@ -476,16 +454,7 @@ def cholder():
 
     # Get latest CCASS date if none specified
     if not d:
-        try:
-            result = execute_query(
-                "SELECT val FROM enigma.log WHERE name='CCASSdateDone'"
-            )
-            if result and result[0]["val"]:
-                d = result[0]["val"]
-            else:
-                d = "2025-10-17"  # Fallback
-        except:
-            d = "2025-10-17"
+        d = watermarks.ccass_done()
 
     # Get max settlement date <= requested date
     try:
@@ -678,7 +647,7 @@ def choldings():
     sort_param = request.args.get("sort", "holddn")
 
     if not d:
-        d = "2025-10-17"  # Placeholder
+        d = watermarks.ccass_done()
 
     # Determine sort order
     sort_orders = {
@@ -1638,14 +1607,7 @@ def cconchist():
             stock_listings = []
 
         # Get latest CCASS date for navigation links
-        try:
-            result = execute_query(
-                "SELECT val FROM enigma.log WHERE name = 'CCASSdateDone'"
-            )
-            if result and result[0]["val"]:
-                d = result[0]["val"]
-        except Exception:
-            pass
+        d = watermarks.ccass_done()
 
     # Determine sort order
     sort_orders = {
@@ -2079,16 +2041,7 @@ def ncipchg():
 
     # Get latest CCASS date if none specified
     if not d2:
-        try:
-            result = execute_query(
-                "SELECT val FROM enigma.log WHERE name='CCASSdateDone'"
-            )
-            if result and result[0]["val"]:
-                d2 = result[0]["val"]
-            else:
-                d2 = "2025-10-17"
-        except:
-            d2 = "2025-10-17"
+        d2 = watermarks.ccass_done()
 
     # Default d1 to day before d2 if not specified
     if not d1:
@@ -2679,11 +2632,7 @@ def portchg():
             pass
 
     # Get latest CCASS date
-    try:
-        ccass_done = execute_query("SELECT val FROM enigma.log WHERE name='CCASSdateDone'")
-        ccass_date = ccass_done[0]["val"] if ccass_done else str(dt_date.today() - timedelta(days=1))
-    except:
-        ccass_date = str(dt_date.today() - timedelta(days=1))
+    ccass_date = watermarks.ccass_done()
 
     # Get date range
     d2 = get_str("d", ccass_date)
@@ -3013,14 +2962,7 @@ def brokhist():
             stock_listings = []
 
         # Get latest CCASS date for navigation links
-        try:
-            result = execute_query(
-                "SELECT val FROM enigma.log WHERE name = 'CCASSdateDone'"
-            )
-            if result and result[0]["val"]:
-                d = result[0]["val"]
-        except Exception:
-            pass
+        d = watermarks.ccass_done()
 
     # Query broker holdings history with issued shares
     history = []

--- a/webbsite/routes/dbpub/market_data.py
+++ b/webbsite/routes/dbpub/market_data.py
@@ -9,6 +9,7 @@ import io
 import re
 from webbsite.db import execute_query, get_db
 from webbsite.asp_helpers import get_int, get_bool, get_str
+from webbsite import watermarks
 
 bp = Blueprint("dbpub_market_data", __name__)
 
@@ -217,16 +218,8 @@ def alltotrets():
         pcsig,
     )
 
-    # Get max quote dates from log table
-    max_dates = execute_query(
-        """
-        SELECT val FROM enigma.log
-        WHERE name IN ('MBquotesDate', 'GEMquotesDate')
-        ORDER BY val
-        LIMIT 1
-    """
-    )
-    max_date = max_dates[0]["val"] if max_dates else str(date.today())
+    # Max quote date = min(MBquotesDate, GEMquotesDate) — follows the daily refresh.
+    max_date = watermarks.quotes_end()
 
     # Parse parameters with validation
     inc_ipo = get_bool("i")

--- a/webbsite/routes/dbpub/statistics.py
+++ b/webbsite/routes/dbpub/statistics.py
@@ -10,29 +10,30 @@ import re
 from sqlalchemy import text
 from webbsite.db import execute_query, execute_scalar, get_db
 from webbsite.asp_helpers import get_int, get_bool, get_str, get_dbl
+from webbsite import watermarks
 
 import json
 import os
 import tempfile
 from pathlib import Path
 
-# Webb-site is a frozen archive; the last trading date in the dataset.
-# Any "to" date >= this is equivalent to "current" (no quotes exist after it),
-# so the default leagueDirsHK table is constant and safe to cache to disk.
-DATA_END = date(2025, 10, 10)
+def _league_cache_dir():
+    return os.environ.get("LEAGUE_CACHE_DIR") or os.path.join(
+        os.path.expanduser("~"), ".cache", "webbsite"
+    )
 
 
 def _league_cache_path():
-    """On-disk path for the cached default leagueDirsHK result.
+    """On-disk path for the cached default leagueDirsHK result, KEYED BY the current
+    data watermark.
 
-    Persists across app restarts (so the heavy ~23k cagrel() compute runs at
-    most once per dataset). Overridable via LEAGUE_CACHE_DIR; defaults to
-    ~/.cache/webbsite (the service user's HOME, which it owns and can write).
+    The default table (no from-date, current to-date, min 3 positions, not hidden)
+    is constant *for a given dataset*, so it is computed at most once and served from
+    disk. Keying the filename by the quotes watermark means a daily refresh naturally
+    invalidates it — the first hit after new data recomputes once, and stale files
+    are swept in :func:`_save_league_cache`. Overridable via LEAGUE_CACHE_DIR.
     """
-    base = os.environ.get("LEAGUE_CACHE_DIR") or os.path.join(
-        os.path.expanduser("~"), ".cache", "webbsite"
-    )
-    return os.path.join(base, "leaguedirshk_default.json")
+    return os.path.join(_league_cache_dir(), f"leaguedirshk_default_{watermarks.quotes_end()}.json")
 
 
 def _load_league_cache():
@@ -44,7 +45,8 @@ def _load_league_cache():
 
 
 def _save_league_cache(rows):
-    """Best-effort atomic write; a failure just means the next hit recomputes."""
+    """Best-effort atomic write; a failure just means the next hit recomputes.
+    Also sweeps older watermark-keyed cache files so they don't accumulate."""
     try:
         path = _league_cache_path()
         os.makedirs(os.path.dirname(path), exist_ok=True)
@@ -52,6 +54,10 @@ def _save_league_cache(rows):
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(rows, f)
         os.replace(tmp, path)
+        keep = os.path.basename(path)
+        for old in Path(_league_cache_dir()).glob("leaguedirshk_default_*.json"):
+            if old.name != keep:
+                old.unlink(missing_ok=True)
     except OSError:
         pass
 
@@ -4279,7 +4285,7 @@ def league_dirs_hk():
         and not c
         and min_pos == 3
         and hide == "N"
-        and date.fromisoformat(to_date) >= DATA_END
+        and date.fromisoformat(to_date) >= watermarks.data_end()
     )
     if is_default:
         results = _load_league_cache()

--- a/webbsite/routes/sitemap.py
+++ b/webbsite/routes/sitemap.py
@@ -23,12 +23,12 @@ from flask import Blueprint, Response, abort, current_app
 
 from webbsite import ROBOTS_DISALLOW
 from webbsite.db import execute_query
+from webbsite import watermarks
 
 bp = Blueprint("sitemap", __name__)
 
 _URLS_PER_SITEMAP = 50000  # sitemaps.org protocol cap
-_cache: dict[str, list[str]] = {}  # data is static -> memoise per worker
-DATA_FREEZE = "2025-10-10"  # data collection ended here; every page's <lastmod>
+_cache: dict[str, list[str]] = {}  # URL lists are structural -> memoise per worker
 
 
 def _host() -> str:
@@ -173,9 +173,10 @@ def sitemap_child(name: str, page: int) -> Response:
     if start >= len(paths) and not (page == 0 and not paths):
         abort(404)
     host = _host()
+    lastmod = watermarks.quotes_end()  # follows the daily refresh (evaluated per request)
     chunk = paths[start:start + _URLS_PER_SITEMAP]
     items = "".join(
-        f"<url><loc>https://{host}{escape(p)}</loc><lastmod>{DATA_FREEZE}</lastmod></url>"
+        f"<url><loc>https://{host}{escape(p)}</loc><lastmod>{lastmod}</lastmod></url>"
         for p in chunk
     )
     return _xml_response(

--- a/webbsite/templates/includes/_renavon_cta.html
+++ b/webbsite/templates/includes/_renavon_cta.html
@@ -1,13 +1,16 @@
 {#
-  Renavon cross-sell — a CONTEXTUAL bridge from the (frozen) Webb-site archive to
-  Renavon's live, maintained datasets.
+  Renavon cross-sell — a CONTEXTUAL bridge from the Webb-site archive to Renavon's
+  live, maintained datasets.
 
   Context for editors:
   - Webb-site is the late David Webb's data, released CC-BY 4.0 and served here as
-    a free, read-only archive FROZEN at 2025-10-10.
+    a free, read-only archive. Collection was revived in 2026 (renavon pipelines
+    reverse-feed fresh rows), so the archive is refreshed daily — the banner shows
+    how current it is via {{ data_asof }} (the live quotes watermark).
   - Renavon maintains its OWN live pipelines for the same public sources (SFC,
-    HKEX, Companies Registry). So this is an honest "the archive is frozen; here's
-    the live version" pointer — NOT a resell of the CC-BY archive.
+    HKEX, Companies Registry) with richer tooling (bulk CSV/Excel, API). So this is
+    an honest "here's the same data with live tooling" pointer — NOT a resell of
+    the CC-BY archive.
   - Keep the tone understated out of respect for the archive.
 
   This replaces the earlier hardcoded, generic, untracked banner that pointed at
@@ -40,7 +43,7 @@
 {%- endif -%}
 {%- set _cta = 'explore the live data on Renavon' if _ds == 'catalog' else 'see the live data on Renavon' -%}
 <div id="renavon-banner" style="background:#1a1a2e;border-bottom:2px solid #0891b2;padding:8px 16px;text-align:center;font-family:Arial,sans-serif;font-size:13px;">
-    <span style="color:#e2e8f0;">This is a free archive, frozen at 10&nbsp;Oct&nbsp;2025. For a live, maintained {{ _what }} &mdash; bulk CSV/Excel and API &mdash;</span>
+    <span style="color:#e2e8f0;">This is a free archive of Webb-site data{% if data_asof %}, current to {{ data_asof }}{% endif %}. For a live, maintained {{ _what }} &mdash; bulk CSV/Excel and API &mdash;</span>
     <a href="{{ _url }}?utm_source=webbsite&amp;utm_medium=cta&amp;utm_campaign=bridge&amp;ref=webbsite&amp;ref_path={{ request.path | urlencode }}"
        target="_blank" rel="noopener"
        onclick="if(window.posthog){posthog.capture('bridge_cta_click',{target_dataset:'{{ _ds }}',source_path:location.pathname})}"

--- a/webbsite/watermarks.py
+++ b/webbsite/watermarks.py
@@ -1,0 +1,61 @@
+"""Dataset watermarks from ``enigma.log``, cached per-process for ~5 minutes.
+
+The archive is no longer frozen — the daily refresh loader advances these keys as
+fresh CCASS/quotes rows land (see ``deploy/README`` "Daily data refresh"). Routes
+read the current watermark instead of a hardcoded freeze date, so "latest" views
+follow the data. Cached per gunicorn worker with a short TTL: the watermark changes
+at most once a day, so a few minutes of staleness is invisible, and this avoids a
+per-request ``enigma.log`` round-trip on every page.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import date
+
+from webbsite.db import execute_scalar
+
+_TTL = 300.0  # seconds
+_cache: dict[str, tuple[str, float]] = {}  # name -> (val, monotonic fetched-at)
+
+# The last values ever true of the frozen archive. Used ONLY when the DB row is
+# missing or the query fails and nothing is cached yet — never in steady state.
+_FALLBACK = {
+    "CCASSdateDone": "2025-10-17",
+    "MBquotesDate": "2025-10-10",
+    "GEMquotesDate": "2025-10-10",
+}
+
+
+def log_val(name: str) -> str:
+    """The current ``enigma.log`` value for ``name`` (ISO date string), memoised.
+
+    Dict get/set is GIL-atomic, so no lock is needed (worst case, two workers each
+    do one redundant fetch). Requires an app context (all call sites have one).
+    """
+    hit = _cache.get(name)
+    if hit and time.monotonic() - hit[1] < _TTL:
+        return hit[0]
+    try:
+        val = execute_scalar("SELECT val FROM enigma.log WHERE name = %s", (name,))
+        val = val or _FALLBACK[name]
+    except Exception:
+        # DB hiccup: prefer a stale cached value; else the frozen-archive fallback.
+        return hit[0] if hit else _FALLBACK[name]
+    _cache[name] = (val, time.monotonic())
+    return val
+
+
+def ccass_done() -> str:
+    """Latest CCASS settlement date loaded (``CCASSdateDone``), ISO string."""
+    return log_val("CCASSdateDone")
+
+
+def quotes_end() -> str:
+    """Latest quotes date — the min of the two boards (ISO strings compare)."""
+    return min(log_val("MBquotesDate"), log_val("GEMquotesDate"))
+
+
+def data_end() -> date:
+    """Latest quotes date as a ``date`` (the market-data upper bound)."""
+    return date.fromisoformat(quotes_end())


### PR DESCRIPTION
## What

The archive is being **refreshed daily** (renavon reverse-feed, Phase 3). This makes the site follow the data instead of a hardcoded freeze date, and preps the edge cache so the loader will **never need to purge Cloudflare**. Ship this **before** the loader runs — this PR's own deploy performs the one full edge purge.

## Changes

- **New `webbsite/watermarks.py`** — the single source of the `enigma.log` dataset dates (`CCASSdateDone`, `MB`/`GEMquotesDate`) with a per-worker ~5-min TTL cache and a frozen-archive fallback. The **one** sanctioned home of the old freeze constants.
- **`__init__.py` cache ladder** — a data page's edge TTL now follows the **age of the date it pins** (`d2` then `d`; `d1`-alone / no-date = "latest"):
  - latest views → **1h browser / 4h edge** (a refresh shows up within hours, no purge)
  - `>14d` old → 1d / 30d · `>1y` old → 7d / 1y
  Extracted into pure `_data_page_ttls` / `_asof_from_args` (unit-tested, no DB). CSV exports made date-aware the same way. Plus a `data_asof`/`ccass_asof` context processor.
  - *Accepted trade-off:* high-cardinality no-date crawler pages (`orgdata.asp?p=…`) drop 30d→4h edge; they render refreshed data, so this is correct (mitigation ladder if origin load bites).
- **Un-hardcode `2025-10-17` / the freeze** across `routes/ccass.py` (every `CCASSdateDone` site → `watermarks.ccass_done()`; the live `MAX(atDate) FROM ccass.dailylog` kept, only its fallback swapped), `statistics.py` (`DATA_END` → `watermarks.data_end()`, and the leagueDirsHK disk cache **keyed by the watermark** so a refresh recomputes once and sweeps stale files), `market_data.py` (`MB`/`GEMquotesDate` → `watermarks.quotes_end()`), `sitemap.py` (`DATA_FREEZE` → `watermarks.quotes_end()`, so `<lastmod>` follows the refresh), and `_renavon_cta.html` ("frozen at 10 Oct 2025" → "current to {{ data_asof }}").

## Tests

`tests/test_cache_headers.py` (runnable, no DB): the TTL-ladder matrix, the watermark fallback path, and a **grep gate** proving `DATA_END`/`DATA_FREEZE`/`2025-10-17` are gone from `webbsite/` (except the `watermarks.py` fallback). No new ruff errors vs master; app + all changed modules import cleanly. Full end-to-end header verification against a live DB is a manual step (local `enigma_pg` isn't provisioned here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)