### PR TITLE
feat(refresh): pull-based R2 → Postgres daily loader (ADR 001)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,8 @@
 # Deploy artefacts (droplet `webbsite-web`)
 
-Hosts the **frozen** Webb-site archive (the late David Webb's CC-BY data, data stops 2025-10-10)
-on a single DigitalOcean droplet, migrated off Render. Self-hosted PostgreSQL + gunicorn under
+Hosts the Webb-site archive (the late David Webb's CC-BY data; frozen baseline 2025-10-10,
+**refreshed daily** from renavon pipelines — see "Daily data refresh" below) on a single
+DigitalOcean droplet, migrated off Render. Self-hosted PostgreSQL + gunicorn under
 systemd, fronted by Caddy + Cloudflare. Tracked here so changes go through PRs, not hand-edits.
 
 ## Topology
@@ -20,8 +21,10 @@ systemd, fronted by Caddy + Cloudflare. Tracked here so changes go through PRs, 
 ## Layout
 ```
 deploy/
-  systemd/webbsite.service   # gunicorn unit (captured from the box)
-  Caddyfile                  # /etc/caddy/Caddyfile (captured from the box)
+  systemd/webbsite.service           # gunicorn unit (captured from the box)
+  systemd/webbsite-refresh.service   # daily R2 -> Postgres loader (oneshot)
+  systemd/webbsite-refresh.timer     # fires the loader 02:45 + 06:45 UTC
+  Caddyfile                          # /etc/caddy/Caddyfile (captured from the box)
   README.md
 ```
 
@@ -61,8 +64,91 @@ curl -fsS https://webbsite.renavon.com/health  # via Caddy + Cloudflare
 ```
 The edge purge is automatic on the next timer deploy; `site-deploy/bin/cf-purge.sh` is the tool if you need to force one.
 
+## Daily data refresh (R2 → Postgres)
+
+The frozen 2025-10-10 baseline is **refreshed daily** by a pull-based loader (ADR
+`docs/architecture/decisions/001-pull-based-postgres-refresh.md`): the renavon
+`renavon-webbsite-refresh` cron publishes 8 Parquet exports + `_manifest.json` to
+`r2://hkdata/webbsite-refresh/` at 22:00 UTC Mon–Fri; `webbsite-refresh.timer` fires
+`scripts/refresh/refresh.py` at 02:45/06:45 UTC, which stages, validates, and upserts into
+`ccass.{holdings,parthold,dailylog,bigchanges,quotes,pquotes,unquotes,calendar}` +
+`enigma.issuedshares` in ONE transaction, then advances the `enigma.log` watermarks
+(`MBquotesDate`/`GEMquotesDate` = quotes max; `CCASSdateDone` = min(ccass, quotes)) that
+`webbsite/watermarks.py` serves to the app. No cache purge — mutable pages sit on the
+1h/4h TTL ladder and self-heal within ≤4h.
+
+**The `webbsite_refresh` role** (loader's only credential — no DELETE/TRUNCATE/DDL):
+```sql
+CREATE ROLE webbsite_refresh LOGIN PASSWORD '<generate>';
+GRANT CONNECT, TEMPORARY ON DATABASE enigma TO webbsite_refresh;
+GRANT USAGE ON SCHEMA ccass, enigma TO webbsite_refresh;
+GRANT SELECT, INSERT, UPDATE ON
+    ccass.holdings, ccass.parthold, ccass.dailylog, ccass.bigchanges,
+    ccass.quotes, ccass.pquotes, ccass.unquotes, ccass.calendar,
+    enigma.issuedshares TO webbsite_refresh;
+GRANT SELECT ON enigma.issue TO webbsite_refresh;
+GRANT SELECT, UPDATE (val) ON enigma.log TO webbsite_refresh;
+GRANT MAINTAIN ON  -- PG17: ANALYZE after load
+    ccass.holdings, ccass.parthold, ccass.dailylog, ccass.bigchanges,
+    ccass.quotes, ccass.pquotes, ccass.unquotes, ccass.calendar,
+    enigma.issuedshares TO webbsite_refresh;
+```
+After creating it, **verify the negative**: `DELETE FROM ccass.quotes` as
+`webbsite_refresh` must fail with `permission denied`.
+
+**Pre-flight** (once): the three log keys must already exist — the loader only
+UPDATEs them (`SELECT name, val FROM enigma.log WHERE name IN
+('CCASSdateDone','MBquotesDate','GEMquotesDate')` must return 3 rows) — and pick a
+`REFRESH_USERID` that doesn't collide with historical curators (`SELECT DISTINCT
+userid FROM enigma.issuedshares ORDER BY 1` — any unused positive integer).
+
+**`/etc/webbsite/refresh-env`** (root:root 0600 — systemd injects it before
+dropping privileges):
+```
+DATABASE_URL=postgresql://webbsite_refresh:<pw>@localhost:5432/enigma
+R2_ENDPOINT=https://<account>.r2.cloudflarestorage.com
+R2_ACCESS_KEY_ID=...    # Object-Read-only R2 API token scoped to the hkdata bucket
+R2_SECRET_ACCESS_KEY=...
+R2_BUCKET=hkdata
+R2_PREFIX=webbsite-refresh
+REFRESH_USERID=<chosen above>
+HC_URL=https://hc-ping.com/<uuid>   # optional healthchecks.io check (daily, grace 6h)
+```
+The R2 token must be **Object Read only**, scoped to the `hkdata` bucket (Cloudflare
+dashboard → R2 → Manage API Tokens). Never reuse a write-capable key here.
+
+**Install / enable:**
+```bash
+sudo cp /srv/webbsite/deploy/systemd/webbsite-refresh.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now webbsite-refresh.timer
+```
+
+**First supervised run:** `sudo systemctl start webbsite-refresh` after a manual
+`--dry-run` as the service user:
+```bash
+sudo -u webbsite sh -c 'cd /srv/webbsite && set -a && . /etc/webbsite/refresh-env && set +a && env HOME=/srv/webbsite /usr/local/bin/uv run --script scripts/refresh/refresh.py --dry-run'
+```
+(Root can read the env file; the one-liner is for the supervised bootstrap only.)
+
+**Monitoring:** the loader pings `HC_URL` on success **only while fresh**
+(`CCASSdateDone` within 4 trading days of the latest `ccass.calendar` row) and
+`/fail` otherwise — so a silently-wedged upstream trips the healthcheck even
+though the loader itself exits 0. Exit codes: 0 loaded/up-to-date, 1 validation
+(nothing committed), 2 infrastructure.
+
+**Corrections / rollback:** renavon re-exports and the loader re-applies
+(idempotent upserts). Row *retraction* is admin-only SQL by design — the loader
+role cannot DELETE. Pages self-heal within the ≤4h edge TTL; no purge needed.
+
+**Local validation:** see `tests/refresh/` (schema fixture + feed generator +
+the negative flags) — the full ladder ran green 2026-07-19: dry-run, real load,
+idempotent no-op rerun, `--poison`/`--bad-counts`/`--pre-freeze`/missing-log-key
+each exit 1 with nothing committed, role-parity denials, and a real 3.9M-row
+feed load in 43s.
+
 ## Rebuild the data (rare)
-The archive is static, so there is no scheduled import. To reload, restore the `pg_dump` archive
+To reload the **frozen baseline**, restore the `pg_dump` archive
 held in Cloudflare R2 (or rebuild from the canonical Google Drive release):
 ```bash
 # directory-format parallel restore as postgres, objects owned by webbsite

--- a/deploy/systemd/webbsite-refresh.service
+++ b/deploy/systemd/webbsite-refresh.service
@@ -1,0 +1,39 @@
+# Daily R2 -> Postgres refresh loader (ADR 001). Pulled by webbsite-refresh.timer;
+# runs scripts/refresh/refresh.py under the restricted webbsite_refresh DB role.
+# Source of truth — keep in sync with the box (like webbsite.service).
+[Unit]
+Description=Webb-site data refresh (R2 -> Postgres)
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=webbsite
+Group=webbsite
+WorkingDirectory=/srv/webbsite
+# Secrets stay root:root 0600 — systemd injects the EnvironmentFile before
+# dropping privileges, so the webbsite user never needs read access to it.
+EnvironmentFile=/etc/webbsite/refresh-env
+Environment=HOME=/srv/webbsite
+ExecStart=/usr/local/bin/uv run --script scripts/refresh/refresh.py
+TimeoutStartSec=45min
+StandardOutput=journal
+StandardError=journal
+
+# Sandbox mirrors webbsite.service; ReadWritePaths for the uv script cache
+# (under HOME) + parquet tmpdir (PrivateTmp).
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+LockPersonality=yes
+SystemCallArchitectures=native
+ReadWritePaths=/srv/webbsite
+ProtectHostname=yes
+ProtectClock=yes

--- a/deploy/systemd/webbsite-refresh.timer
+++ b/deploy/systemd/webbsite-refresh.timer
@@ -1,0 +1,18 @@
+# Fires the daily R2 -> Postgres refresh (webbsite-refresh.service).
+#
+# Two firings: the renavon-webbsite-refresh cron (render.yaml in the renavon
+# monorepo) publishes the feed at 22:00 UTC Mon-Fri (~30-45 min run), so 02:45
+# UTC comfortably follows it; 06:45 is the retry pass — the loader no-ops
+# ("up to date") when the first firing already loaded, and self-heals when the
+# upstream cron ran late or the first firing hit a transient failure.
+[Unit]
+Description=Daily Webb-site data refresh timer
+
+[Timer]
+OnCalendar=*-*-* 02:45:00 UTC
+OnCalendar=*-*-* 06:45:00 UTC
+RandomizedDelaySec=600
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/architecture/decisions/001-pull-based-postgres-refresh.md
+++ b/docs/architecture/decisions/001-pull-based-postgres-refresh.md
@@ -1,0 +1,67 @@
+# ADR 001 — Pull-based R2 → Postgres refresh
+
+Date: 2026-07-19 · Status: accepted
+
+## Context
+
+The archive froze at 2025-10-10 when David Webb's scrapers retired. Collection
+was revived as renavon-monorepo pipelines (Scrapy → bronze R2 → ClickHouse →
+dbt), which now produce webbsite-shaped exports for CCASS holdings/dailylog/
+bigchanges, issued shares, quotes (quotes/pquotes/unquotes) and the settlement
+calendar. Fresh rows must reach this droplet's Postgres (`enigma`/`ccass`)
+daily without compromising the archive's integrity or the host's security
+posture (tailnet-only SSH, no inbound surface beyond Cloudflare→Caddy).
+
+## Decision
+
+A **pull-based loader** on the droplet (`scripts/refresh/refresh.py`, PEP 723
+uv script, systemd timer 02:45/06:45 UTC):
+
+- **The droplet pulls; renavon pushes nothing.** Renavon's scoped sync writes
+  Parquet + `_manifest.json` to `r2://hkdata/webbsite-refresh/`; the loader
+  reads with an Object-Read-only R2 token. Renavon holds no credentials to
+  this host or database.
+- **Manifest-gated.** Renavon writes the manifest only after a fully clean
+  export run; the loader hard-fails on a table-set mismatch and no-ops when
+  the manifest's watermarks don't advance past `enigma.log`.
+- **One transaction.** TEMP-table staging → validation (row counts vs
+  manifest; hard freeze guard `> 2025-10-10`; PK-duplicate check; bigchanges
+  sanity bound; issuedshares FK quarantine of renavon-minted issueids) →
+  `INSERT … ON CONFLICT DO UPDATE` into the 9 targets (holdings and parthold
+  from one file) → forward-only watermark UPDATE — all commit or roll back
+  together, so the site can never claim freshness the data doesn't have.
+- **Delete-less role.** `webbsite_refresh` has SELECT/INSERT/UPDATE on the 9
+  targets + `UPDATE(val)` on `enigma.log` + MAINTAIN (ANALYZE) — no DELETE,
+  no TRUNCATE, no DDL. Re-running a load is a no-op; corrections flow by
+  renavon re-export + idempotent re-apply; row retraction is admin-only SQL.
+- **Short edge TTLs instead of purges.** The freshness rework (webbsite #25)
+  put mutable "latest" views on a 1h/4h TTL ladder keyed off `enigma.log`
+  watermarks, so a load becomes visible within ≤4h with no cache purge and no
+  coupling between the loader and Cloudflare.
+
+## Alternatives rejected
+
+- **SSH push from renavon** — grants an external system shell on the origin;
+  inverts the trust boundary for zero functional gain.
+- **Direct Postgres writes from renavon** — requires exposing Postgres beyond
+  localhost (or tailnet-joining a Render cron) and couples renavon deploys to
+  this database's schema; the R2 feed is a clean, replayable interface.
+- **Logical replication from a renavon-side Postgres** — no such Postgres
+  exists (renavon is ClickHouse); introducing one to replicate 8 tables is
+  pure operational surface.
+- **Purge-based freshness** — edge purges couple the loader to Cloudflare
+  credentials and fail unsafe (a purge without a load serves slow misses; a
+  load without a purge serves stale for 30d under the old TTLs). The TTL
+  ladder self-heals within hours with neither credential nor coupling.
+
+## Consequences
+
+- The site's freshness lag is bounded by feed-publish (22:00 UTC) + load
+  (02:45 UTC) + edge TTL (≤4h): fresh data is user-visible by ~07:00 UTC
+  worst-case, no purges involved.
+- `issuedshares` rows for post-freeze listings (renavon-minted issueids ≥9e6)
+  quarantine until `enigma.issue` itself is refreshed — a documented gap, not
+  an error; the dailylog/holdings paths carry those securities meanwhile.
+- A wedged upstream (no new manifest) leaves the loader silently no-opping —
+  covered by the healthcheck's freshness budget (success ping only while
+  `CCASSdateDone` is within 4 trading days of the latest calendar row).

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,4 @@
+# Architecture Decision Records
+
+Numbered, immutable records of load-bearing decisions. Supersede with a new
+ADR rather than editing history.

--- a/scripts/refresh/refresh.py
+++ b/scripts/refresh/refresh.py
@@ -1,0 +1,543 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "boto3>=1.34",
+#     "pyarrow>=16",
+#     "psycopg2-binary>=2.9",
+# ]
+# ///
+"""Pull-based R2 -> Postgres refresh loader (ADR 001).
+
+Pulls the renavon `webbsite-refresh` feed (8 Parquet exports + _manifest.json,
+produced daily by the renavon-webbsite-refresh cron) and upserts it into the
+live enigma/ccass schemas under the restricted `webbsite_refresh` role, then
+advances the enigma.log watermarks the Flask app's freshness layer
+(webbsite/watermarks.py) reads.
+
+Design invariants (see docs/architecture/decisions/001-*.md):
+  * The droplet PULLS; renavon has no credentials to this host or database.
+  * The manifest gates everything: written by renavon only after a fully
+    clean export run, so a partial upstream snapshot is never loaded.
+  * One transaction: staging, validation, upserts into all targets, and the
+    watermark advance COMMIT (or roll back) together — the site can never
+    claim a freshness the data doesn't have.
+  * Idempotent upserts (INSERT ... ON CONFLICT DO UPDATE) under a role with
+    NO DELETE/TRUNCATE/DDL: re-running a load is a no-op, corrections flow
+    by re-export + re-apply, and row retraction is a documented admin path.
+  * Hard freeze guard: no staged row may carry a date <= 2025-10-10 — the
+    frozen archive is renavon's input baseline, never its write target.
+
+Usage (normally driven by webbsite-refresh.timer):
+    uv run --script scripts/refresh/refresh.py [--dry-run] [--confirm]
+        [--source DIR] [--table NAME]
+
+Exit codes: 0 = loaded or already up to date; 1 = validation failure (nothing
+committed); 2 = infrastructure failure (R2/network/Postgres unavailable).
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import logging
+import os
+import sys
+import tempfile
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+FREEZE_DATE = "2025-10-10"  # the frozen-archive boundary; staged rows must be strictly after
+
+log = logging.getLogger("webbsite-refresh")
+
+
+@dataclass(frozen=True)
+class Target:
+    """One manifest dataset -> one or two Postgres targets."""
+
+    dataset: str  # manifest key / R2 folder name
+    columns: tuple[str, ...]  # export column order (loader drops the trailing `id`)
+    date_column: str  # freeze-guard + watermark column
+    upserts: tuple[tuple[str, tuple[str, ...]], ...]  # (pg_table, pk_columns)
+
+
+TABLES: dict[str, Target] = {
+    t.dataset: t
+    for t in (
+        Target(
+            "webbsite_ccass_holdings",
+            ("partid", "issueid", "holding", "atdate"),
+            "atdate",
+            # One file feeds BOTH holdings mirrors (issueid-major and partid-major PKs).
+            (
+                ("ccass.holdings", ("issueid", "partid", "atdate")),
+                ("ccass.parthold", ("partid", "issueid", "atdate")),
+            ),
+        ),
+        Target(
+            "webbsite_ccass_dailylog",
+            (
+                "atdate", "issueid", "intermedhldg", "intermedcnt", "nciphldg",
+                "ncipcnt", "ciphldg", "cipcnt", "c5", "c10", "custhldg", "brokhldg",
+            ),
+            "atdate",
+            (("ccass.dailylog", ("issueid", "atdate")),),
+        ),
+        Target(
+            "webbsite_ccass_bigchanges",
+            ("atdate", "issueid", "partid", "stkchg", "prevdate"),
+            "atdate",
+            (("ccass.bigchanges", ("atdate", "issueid", "partid")),),
+        ),
+        Target(
+            "webbsite_issuedshares",
+            ("issueid", "atdate", "outstanding"),
+            "atdate",
+            (("enigma.issuedshares", ("issueid", "atdate")),),
+        ),
+        Target(
+            "webbsite_quotes",
+            (
+                "issueid", "atdate", "prevclose", "closing", "ask", "bid", "high",
+                "low", "vol", "turn", "susp", "newsusp", "noclose",
+            ),
+            "atdate",
+            (("ccass.quotes", ("issueid", "atdate")),),
+        ),
+        Target(
+            "webbsite_pquotes",
+            (
+                "issueid", "atdate", "prevclose", "closing", "ask", "bid", "high",
+                "low", "vol", "turn", "susp", "newsusp", "noclose",
+            ),
+            "atdate",
+            (("ccass.pquotes", ("issueid", "atdate")),),
+        ),
+        Target(
+            "webbsite_unquotes",
+            (
+                "stockcode", "atdate", "prevclose", "closing", "ask", "bid", "high",
+                "low", "vol", "turn", "susp", "newsusp", "noclose",
+            ),
+            "atdate",
+            (("ccass.unquotes", ("stockcode", "atdate")),),
+        ),
+        Target(
+            "webbsite_calendar",
+            ("tradedate", "settledate", "deferred"),
+            "tradedate",
+            (("ccass.calendar", ("tradedate",)),),
+        ),
+    )
+}
+
+# enigma.log keys this loader owns (all must pre-exist — see deploy/README).
+LOG_CCASS = "CCASSdateDone"
+LOG_MB = "MBquotesDate"
+LOG_GEM = "GEMquotesDate"
+
+
+class ValidationError(Exception):
+    """Data failed a pre-commit check: exit 1, nothing committed."""
+
+
+# ---------------------------------------------------------------------------
+# Configuration (from /etc/webbsite/refresh-env via the systemd unit)
+# ---------------------------------------------------------------------------
+
+
+def env(name: str, default: str | None = None) -> str:
+    val = os.environ.get(name, default)
+    if val is None:
+        raise SystemExit(f"missing required environment variable {name}")
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Fetch: manifest + parquet, from R2 (boto3) or a local --source dir
+# ---------------------------------------------------------------------------
+
+
+def r2_client():
+    import boto3
+
+    return boto3.client(
+        "s3",
+        endpoint_url=env("R2_ENDPOINT"),
+        aws_access_key_id=env("R2_ACCESS_KEY_ID"),
+        aws_secret_access_key=env("R2_SECRET_ACCESS_KEY"),
+        region_name="auto",
+    )
+
+
+def fetch_manifest(source: Path | None) -> dict:
+    if source:
+        raw = (source / "_manifest.json").read_bytes()
+    else:
+        obj = r2_client().get_object(
+            Bucket=env("R2_BUCKET", "hkdata"),
+            Key=f"{env('R2_PREFIX', 'webbsite-refresh')}/_manifest.json",
+        )
+        raw = obj["Body"].read()
+    manifest = json.loads(raw)
+    tables = manifest.get("tables")
+    if not isinstance(tables, dict):
+        raise ValidationError("manifest has no tables map")
+    # Contract check: EXACT set equality. An unknown dataset means renavon
+    # ships something this loader doesn't understand; a missing one means the
+    # snapshot is incomplete. Either way: hard fail, load nothing.
+    if set(tables) != set(TABLES):
+        raise ValidationError(
+            f"manifest table set mismatch: manifest-only="
+            f"{sorted(set(tables) - set(TABLES))} loader-only="
+            f"{sorted(set(TABLES) - set(tables))}"
+        )
+    return manifest
+
+
+def download_parquet(dataset: str, entry: dict, dest_dir: Path, source: Path | None) -> Path:
+    dest = dest_dir / f"{dataset}.parquet"
+    if source:
+        # Local fixture layout mirrors R2: <source>/<dataset>/data.parquet
+        dest = source / dataset / "data.parquet"
+        if not dest.exists():
+            raise ValidationError(f"fixture file missing: {dest}")
+        return dest
+    r2_client().download_file(env("R2_BUCKET", "hkdata"), entry["key"], str(dest))
+    return dest
+
+
+# ---------------------------------------------------------------------------
+# needs_run: compare manifest watermarks against enigma.log
+# ---------------------------------------------------------------------------
+
+
+def read_log_watermarks(cur) -> dict[str, str]:
+    cur.execute(
+        "SELECT name, val FROM enigma.log WHERE name IN (%s, %s, %s)",
+        (LOG_CCASS, LOG_MB, LOG_GEM),
+    )
+    rows = dict(cur.fetchall())
+    missing = {LOG_CCASS, LOG_MB, LOG_GEM} - set(rows)
+    if missing:
+        # Pre-flight (deploy/README) requires these keys to exist; the loader
+        # only ever UPDATEs them (an INSERT would need broader privileges).
+        raise ValidationError(f"enigma.log keys missing: {sorted(missing)}")
+    return rows
+
+
+def needs_run(manifest: dict, watermarks: dict[str, str]) -> bool:
+    """Anything in the manifest strictly beyond the current watermarks?"""
+    quotes_max = manifest["tables"]["webbsite_quotes"].get("max_atdate")
+    ccass_max = manifest["tables"]["webbsite_ccass_holdings"].get("max_atdate")
+    fresh_quotes = bool(quotes_max) and quotes_max > min(
+        watermarks[LOG_MB], watermarks[LOG_GEM]
+    )
+    fresh_ccass = bool(ccass_max) and ccass_max > watermarks[LOG_CCASS]
+    return fresh_quotes or fresh_ccass
+
+
+# ---------------------------------------------------------------------------
+# Staging + validation + upsert (all inside ONE transaction)
+# ---------------------------------------------------------------------------
+
+
+def stage_table(cur, target: Target, parquet_path: Path, expected_rows: int) -> int:
+    """COPY the parquet (minus the trailing export `id`) into a TEMP table."""
+    import pyarrow.csv as pacsv
+    import pyarrow.parquet as pq
+
+    staging = f"stg_{target.dataset}"
+    first_pg_table = target.upserts[0][0]
+    cols = ", ".join(target.columns)
+    # LIKE the real target so types/NOT NULLs match exactly; drop the columns
+    # the export doesn't carry (issuedshares' modified/userid get set at upsert).
+    cur.execute(
+        f"CREATE TEMP TABLE {staging} ON COMMIT DROP AS "
+        f"SELECT {cols} FROM {first_pg_table} WITH NO DATA"
+    )
+
+    table = pq.read_table(parquet_path)
+    got_cols = table.column_names
+    want_cols = [*target.columns, "id"]
+    if got_cols != want_cols:
+        raise ValidationError(
+            f"{target.dataset}: parquet columns {got_cols} != expected {want_cols}"
+        )
+    table = table.drop_columns(["id"])  # R23 row-identity column — loader contract drops it
+
+    buf = io.BytesIO()
+    pacsv.write_csv(
+        table, buf, pacsv.WriteOptions(include_header=False, quoting_style="needed")
+    )
+    buf.seek(0)
+    cur.copy_expert(f"COPY {staging} ({cols}) FROM STDIN WITH (FORMAT csv)", buf)
+
+    cur.execute(f"SELECT count(*) FROM {staging}")  # noqa: S608 — staging name is loader-owned
+    staged = cur.fetchone()[0]
+    if staged != expected_rows:
+        raise ValidationError(
+            f"{target.dataset}: staged {staged} rows != manifest {expected_rows}"
+        )
+    return staged
+
+
+def validate_staged(cur, target: Target) -> None:
+    staging = f"stg_{target.dataset}"
+    date_col = target.date_column
+
+    # Freeze guard: the frozen archive (<= 2025-10-10) is never a write target.
+    cur.execute(
+        f"SELECT count(*) FROM {staging} WHERE {date_col} <= %s", (FREEZE_DATE,)
+    )
+    if (n := cur.fetchone()[0]) > 0:
+        raise ValidationError(
+            f"{target.dataset}: {n} rows dated on/before the {FREEZE_DATE} freeze"
+        )
+
+    # PK-duplicate guard (one file, one grain).
+    pk = ", ".join(target.upserts[0][1])
+    cur.execute(
+        f"SELECT count(*) FROM (SELECT 1 FROM {staging} "
+        f"GROUP BY {pk} HAVING count(*) > 1) d"
+    )
+    if (n := cur.fetchone()[0]) > 0:
+        raise ValidationError(f"{target.dataset}: {n} duplicate PK groups")
+
+    if target.dataset == "webbsite_ccass_bigchanges":
+        # Sanity bound, not a business rule: |stkchg| beyond 100x issued is
+        # parse corruption. (Values slightly over 1.0 are expected while the
+        # issued-shares series is seed-only — post-freeze issuance missing
+        # from the denominator — and self-heal as daily SDW captures land.)
+        cur.execute(f"SELECT count(*) FROM {staging} WHERE abs(stkchg) > 100")
+        if (n := cur.fetchone()[0]) > 0:
+            raise ValidationError(f"bigchanges: {n} rows with |stkchg| > 100")
+        cur.execute(f"SELECT count(*) FROM {staging} WHERE abs(stkchg) > 1")
+        if (n := cur.fetchone()[0]) > 0:
+            log.warning("bigchanges: %d rows with |stkchg| > 100%% (seed-only denominator era)", n)
+
+
+def quarantine_unknown_issueids(cur) -> int:
+    """issuedshares only: drop staged rows whose issueid is not in enigma.issue.
+
+    The FK (issuedshares_issue -> issue.id1) would reject them; renavon-minted
+    ids (>= 9e6) for post-freeze listings are EXPECTED here until the
+    enigma.issue dimension itself is refreshed — logged and excluded, never an
+    error.
+    """
+    cur.execute(
+        "DELETE FROM stg_webbsite_issuedshares s "
+        "WHERE NOT EXISTS (SELECT 1 FROM enigma.issue i WHERE i.id1 = s.issueid)"
+    )
+    if cur.rowcount:
+        log.warning(
+            "issuedshares: quarantined %d rows with issueids unknown to enigma.issue",
+            cur.rowcount,
+        )
+    return cur.rowcount
+
+
+def upsert(cur, target: Target, refresh_userid: int) -> dict[str, int]:
+    """INSERT ... ON CONFLICT DO UPDATE from staging into each PG target."""
+    staging = f"stg_{target.dataset}"
+    counts = {}
+    for pg_table, pk in target.upserts:
+        cols = list(target.columns)
+        select_cols = ", ".join(cols)
+        insert_cols = select_cols
+        params: tuple = ()
+        if pg_table == "enigma.issuedshares":
+            # The export doesn't carry modified/userid; the BEFORE-UPDATE
+            # trigger only fires on UPDATE, so the INSERT path sets both.
+            insert_cols += ", modified, userid"
+            select_cols += ", now(), %s"
+            params = (refresh_userid,)
+        non_pk = [c for c in cols if c not in pk]
+        set_clause = ", ".join(f"{c} = EXCLUDED.{c}" for c in non_pk)
+        if pg_table == "enigma.issuedshares":
+            set_clause += ", modified = now(), userid = EXCLUDED.userid"
+        conflict_action = f"DO UPDATE SET {set_clause}" if set_clause else "DO NOTHING"
+        cur.execute(
+            f"INSERT INTO {pg_table} ({insert_cols}) "
+            f"SELECT {select_cols} FROM {staging} "
+            f"ON CONFLICT ({', '.join(pk)}) {conflict_action}",
+            params,
+        )
+        counts[pg_table] = cur.rowcount
+    return counts
+
+
+def advance_watermarks(cur, manifest: dict, watermarks: dict[str, str]) -> dict[str, str]:
+    """Forward-only watermark advance, atomic with the data upserts.
+
+    Quotes-before-CCASS (the original scrapers' dependency): MB/GEM advance to
+    the quotes max; CCASSdateDone advances to min(ccass max, MB, GEM) so the
+    site never claims CCASS coverage beyond the quotes that price it.
+    """
+    tables = manifest["tables"]
+    quotes_max = tables["webbsite_quotes"].get("max_atdate")
+    ccass_max = tables["webbsite_ccass_holdings"].get("max_atdate")
+
+    new = dict(watermarks)
+    if quotes_max:
+        new[LOG_MB] = max(new[LOG_MB], quotes_max)
+        new[LOG_GEM] = max(new[LOG_GEM], quotes_max)
+    if ccass_max:
+        new[LOG_CCASS] = max(
+            new[LOG_CCASS], min(ccass_max, new[LOG_MB], new[LOG_GEM])
+        )
+
+    for name in (LOG_MB, LOG_GEM, LOG_CCASS):
+        if new[name] != watermarks[name]:
+            # Forward-only: `val < %s` makes a concurrent/stale run harmless.
+            cur.execute(
+                "UPDATE enigma.log SET val = %s WHERE name = %s AND val < %s",
+                (new[name], name, new[name]),
+            )
+    return new
+
+
+# ---------------------------------------------------------------------------
+# Post-commit: ANALYZE + freshness healthcheck
+# ---------------------------------------------------------------------------
+
+
+def analyze(conn, touched: list[str]) -> None:
+    with conn.cursor() as cur:
+        for t in touched:
+            cur.execute(f"ANALYZE {t}")
+    conn.commit()
+
+
+def freshness_ok(cur, ccass_done: str, budget_trading_days: int = 4) -> bool:
+    """Is CCASSdateDone within N trading days of the latest known trade date?"""
+    cur.execute(
+        "SELECT count(*) FROM ccass.calendar WHERE tradedate > %s", (ccass_done,)
+    )
+    return cur.fetchone()[0] <= budget_trading_days
+
+
+def ping_healthcheck(ok: bool, body: str) -> None:
+    url = os.environ.get("HC_URL")
+    if not url:
+        return
+    try:
+        target = url if ok else f"{url}/fail"
+        urllib.request.urlopen(  # noqa: S310 — operator-configured healthchecks.io URL
+            urllib.request.Request(target, data=body.encode()[:100_000]), timeout=10
+        )
+    except OSError as e:  # never fail the load over a ping
+        log.warning("healthcheck ping failed: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def run(args: argparse.Namespace) -> int:
+    import psycopg2
+
+    manifest = fetch_manifest(args.source)
+    selected = {args.table: TABLES[args.table]} if args.table else TABLES
+
+    conn = psycopg2.connect(env("DATABASE_URL"))
+    conn.autocommit = False
+    try:
+        with conn.cursor() as cur:
+            watermarks = read_log_watermarks(cur)
+            if not args.table and not needs_run(manifest, watermarks):
+                log.info(
+                    "up to date (log: %s) — nothing to load",
+                    {k: watermarks[k] for k in (LOG_CCASS, LOG_MB, LOG_GEM)},
+                )
+                conn.rollback()
+                ping_healthcheck(True, "up to date")
+                return 0
+
+        with tempfile.TemporaryDirectory(prefix="webbsite-refresh-") as tmp:
+            tmp_dir = Path(tmp)
+            files = {
+                name: download_parquet(name, manifest["tables"][name], tmp_dir, args.source)
+                for name in selected
+            }
+
+            with conn.cursor() as cur:
+                # Serialize concurrent loads (timer double-fire, manual run).
+                cur.execute("SELECT pg_advisory_xact_lock(hashtext('webbsite-refresh'))")
+
+                touched: list[str] = []
+                total_upserts: dict[str, int] = {}
+                for name, target in selected.items():
+                    staged = stage_table(
+                        cur, target, files[name], manifest["tables"][name]["rows"]
+                    )
+                    validate_staged(cur, target)
+                    if name == "webbsite_issuedshares":
+                        staged -= quarantine_unknown_issueids(cur)
+                    counts = upsert(cur, target, int(env("REFRESH_USERID", "0")))
+                    total_upserts.update(counts)
+                    touched.extend(t for t, _ in target.upserts)
+                    log.info("%s: staged %d -> upserts %s", name, staged, counts)
+
+                if args.table:
+                    log.warning("--table run: watermarks NOT advanced")
+                    new_marks = watermarks
+                else:
+                    new_marks = advance_watermarks(cur, manifest, watermarks)
+
+            if args.dry_run:
+                conn.rollback()
+                log.info("dry-run: rolled back (would have advanced log to %s)", new_marks)
+                return 0
+            if args.confirm:
+                answer = input(f"COMMIT {sum(total_upserts.values())} upserts, log -> {new_marks}? [y/N] ")
+                if answer.strip().lower() != "y":
+                    conn.rollback()
+                    log.info("aborted by operator; rolled back")
+                    return 0
+
+            conn.commit()
+            log.info("committed; log now %s", new_marks)
+
+        analyze(conn, sorted(set(touched)))
+
+        with conn.cursor() as cur:
+            fresh = freshness_ok(cur, new_marks[LOG_CCASS])
+        conn.rollback()
+        ping_healthcheck(
+            fresh,
+            f"loaded; log={new_marks}"
+            + ("" if fresh else " — STALE beyond the trading-day budget"),
+        )
+        return 0
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--dry-run", action="store_true", help="full pipeline, ROLLBACK at the end")
+    parser.add_argument("--confirm", action="store_true", help="prompt before COMMIT")
+    parser.add_argument("--source", type=Path, default=None, help="local fixture dir instead of R2")
+    parser.add_argument("--table", choices=sorted(TABLES), default=None,
+                        help="load ONE dataset (debugging; watermarks not advanced)")
+    args = parser.parse_args()
+
+    try:
+        return run(args)
+    except ValidationError as e:
+        log.error("VALIDATION FAILED (nothing committed): %s", e)
+        ping_healthcheck(False, f"validation failed: {e}")
+        return 1
+    except Exception as e:  # noqa: BLE001 — top-level infra classifier
+        log.exception("infrastructure failure: %s", e)
+        ping_healthcheck(False, f"infra failure: {e}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/refresh/refresh.py.lock
+++ b/scripts/refresh/refresh.py.lock
@@ -1,0 +1,166 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[manifest]
+requirements = [
+    { name = "boto3", specifier = ">=1.34" },
+    { name = "psycopg2-binary", specifier = ">=2.9" },
+    { name = "pyarrow", specifier = ">=16" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/4f/b93620c09e81b8dd28558e73862d7b61f938c5a9db9366fab4b0bb53512f/boto3-1.43.51.tar.gz", hash = "sha256:b5a416cc703db73b69b22bef563c89c1fb14a4b10a93628d3c7abc4dd1aaf979", size = 112649, upload-time = "2026-07-17T19:33:23.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/7e/86204db9235f08e051a83e039ec5af209211e3ac51ed3644c4350c150b72/boto3-1.43.51-py3-none-any.whl", hash = "sha256:a97057bb609fd38c80448db6a93db770786775dabd651401debf09816d4553d7", size = 140030, upload-time = "2026-07-17T19:33:21.381Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/f5/5a6b4fe037ba689fd4a9eaf31af8b681e4c1eb82debc470d18dec99eac62/botocore-1.43.51.tar.gz", hash = "sha256:e0e5e88585fdb01dcb6b533ac2dd3f18d5d45092a14ccbfd330e3576a4152128", size = 15713861, upload-time = "2026-07-17T19:33:12.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/ca/9080b2f261ad9209e4d790b4282951df46274f786edb5c416a27fb18f4c6/botocore-1.43.51-py3-none-any.whl", hash = "sha256:7c2c538c932bddc95834e177ce6f91dcc388c6a7934b4f8d0db13caa30e3e543", size = 15399252, upload-time = "2026-07-17T19:33:08.808Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/60/a3624f79acea344c16fbef3a94d28b89a8042ddfb8f3e4ca83f538671409/psycopg2_binary-2.9.12.tar.gz", hash = "sha256:5ac9444edc768c02a6b6a591f070b8aae28ff3a99be57560ac996001580f294c", size = 379686, upload-time = "2026-04-21T09:40:34.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/9f/ef4ef3c8e15083df90ca35265cfd1a081a2f0cc07bb229c6314c6af817f4/psycopg2_binary-2.9.12-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5cdc05117180c5fa9c40eea8ea559ce64d73824c39d928b7da9fb5f6a9392433", size = 3712459, upload-time = "2026-04-20T23:34:30.549Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/01/3dd14e46ba48c1e1a6ec58ee599fa1b5efa00c246d5046cd903d0eeb1af1/psycopg2_binary-2.9.12-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3227a3bc228c10d21011a99245edca923e4e8bf461857e869a507d9a41fe9f6", size = 3822936, upload-time = "2026-04-20T23:34:32.77Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/f7/0640e4901119d8a9f7a1784b927f494e2198e213ceb593753d1f2c8b1b30/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:995ce929eede89db6254b50827e2b7fd61e50d11f0b116b29fffe4a2e53c4580", size = 4578676, upload-time = "2026-04-20T23:34:35.18Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/55/44df3965b5f297c50cc0b1b594a31c67d6127a9d133045b8a66611b14dfb/psycopg2_binary-2.9.12-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9fe06d93e72f1c048e731a2e3e7854a5bfaa58fc736068df90b352cefe66f03f", size = 4274917, upload-time = "2026-04-20T23:34:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/4b/74535248b1eac0c9336862e8617c765ac94dac76f9e25d7c4a79588c8907/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40e7b28b63aaf737cb3a1edc3a9bbc9a9f4ad3dcb7152e8c1130e4050eddcb7d", size = 5894843, upload-time = "2026-04-20T23:34:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/ba/f1bf8d2ae71868ad800b661099086ee52bc0f8d9f05be1acd8ebb06757cc/psycopg2_binary-2.9.12-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:89d19a9f7899e8eb0656a2b3a08e0da04c720a06db6e0033eab5928aabe60fa9", size = 4110556, upload-time = "2026-04-20T23:34:44.016Z" },
+    { url = "https://files.pythonhosted.org/packages/45/46/c15706c338403b7c420bcc0c2905aad116cc064545686d8bf85f1999ea00/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:612b965daee295ae2da8f8218ce1d274645dc76ef3f1abf6a0a94fd57eff876d", size = 3655714, upload-time = "2026-04-20T23:34:46.233Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7c/a2d5dc09b64a4564db242a0fe418fde7d33f6f8259dd2c5b9d7def00fb5a/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:b9a339b79d37c1b45f3235265f07cdeb0cb5ad7acd2ac7720a5920989c17c24e", size = 3301154, upload-time = "2026-04-20T23:34:49.528Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/e8/cc8c9a4ce71461f9ec548d38cadc41dc184b34c73e6455450775a9334ccd/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:3471336e1acfd9c7fe507b8bad5af9317b6a89294f9eb37bd9a030bb7bebcdc6", size = 3048882, upload-time = "2026-04-20T23:34:51.86Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/31e2296bc0787c5ab75d3d118e40b239db8151b5192b90b77c72bc9256e9/psycopg2_binary-2.9.12-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7af18183109e23502c8b2ae7f6926c0882766f35b5175a4cd737ad825e4d7a1b", size = 3351298, upload-time = "2026-04-20T23:34:54.124Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a8/75f4e3e11203b590150abed2cf7794b9c9c9f7eceddae955191138b44dde/psycopg2_binary-2.9.12-cp312-cp312-win_amd64.whl", hash = "sha256:398fcd4db988c7d7d3713e2b8e18939776fd3fb447052daae4f24fa39daede4c", size = 2757230, upload-time = "2026-04-20T23:34:56.242Z" },
+    { url = "https://files.pythonhosted.org/packages/91/bb/4608c96f970f6e0c56572e87027ef4404f709382a3503e9934526d7ba051/psycopg2_binary-2.9.12-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7c729a73c7b1b84de3582f73cdd27d905121dc2c531f3d9a3c32a3011033b965", size = 3712419, upload-time = "2026-04-20T23:34:58.754Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/af/48f76af9d50d61cf390f8cd657b503168b089e2e9298e48465d029fcc713/psycopg2_binary-2.9.12-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4413d0caef93c5cf50b96863df4c2efe8c269bf2267df353225595e7e15e8df7", size = 3822990, upload-time = "2026-04-20T23:35:00.821Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/aba0f99397cd811d32e06fc0cc781f1f3ce98bc0e729cb423925085d781a/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4dfcf8e45ebb0c663be34a3442f65e17311f3367089cd4e5e3a3e8e62c978777", size = 4578696, upload-time = "2026-04-20T23:35:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/eaa74021ac4e4d5c2f83d82fc6615a63f4fe6c94dc4e94c3990427053f67/psycopg2_binary-2.9.12-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c41321a14dd74aceb6a9a643b9253a334521babfa763fa873e33d89cfa122fb5", size = 4274982, upload-time = "2026-04-20T23:35:05.583Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ed/c25deff98bd26187ba48b3b250a3ffc3037c46c5b89362534a15d200e0db/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:83946ba43979ebfdc99a3cd0ee775c89f221df026984ba19d46133d8d75d3cd9", size = 5894867, upload-time = "2026-04-20T23:35:07.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/8d0e21ca77373c6c9589e5c4528f6e8f0c08c62cafc76fb0bddb7a2cee22/psycopg2_binary-2.9.12-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:411e85815652d13560fbe731878daa5d92378c4995a22302071890ec3397d019", size = 4110578, upload-time = "2026-04-20T23:35:10.149Z" },
+    { url = "https://files.pythonhosted.org/packages/00/fc/f481e2435bd8f742d0123309174aae4165160ad3ef17c1b99c3622c241d2/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c8ad4c08e00f7679559eaed7aff1edfffc60c086b976f93972f686384a95e2c", size = 3655816, upload-time = "2026-04-20T23:35:12.56Z" },
+    { url = "https://files.pythonhosted.org/packages/53/79/b9f46466bdbe9f239c96cde8be33c1aace4842f06013b47b730dc9759187/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f", size = 3301307, upload-time = "2026-04-20T23:35:15.029Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/7dc003b32fe35024df89b658104f7c8538a8b2dcbde7a4e746ce929742e7/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:98062447aebc20ed20add1f547a364fd0ef8933640d5372ff1873f8deb9b61be", size = 3048968, upload-time = "2026-04-20T23:35:16.757Z" },
+    { url = "https://files.pythonhosted.org/packages/91/58/2dbd7db5c604d45f4950d988506aae672a14126ec22998ced5021cbb76bb/psycopg2_binary-2.9.12-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:66a7685d7e548f10fb4ce32fb01a7b7f4aa702134de92a292c7bd9e0d3dbd290", size = 3351369, upload-time = "2026-04-20T23:35:18.933Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/dee8dcaad07f735824de3d6563bc67119fa6c28257b17977a8d624f02fab/psycopg2_binary-2.9.12-cp313-cp313-win_amd64.whl", hash = "sha256:b6937f5fe4e180aeee87de907a2fa982ded6f7f15d7218f78a083e4e1d68f2a0", size = 2757347, upload-time = "2026-04-20T23:35:21.283Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/708c0dca874acfad6d65314271859899a79007686f3a1f74e82a2ed4b645/psycopg2_binary-2.9.12-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f3b3de8a74ef8db215f22edffb19e32dc6fa41340456de7ec99efdc8a7b3ec2", size = 3712428, upload-time = "2026-04-20T23:35:23.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/39/ddbea9d4b4de6aca9431b6ed253f530f8a02d3b8f9bcfd0dbfe2b3de6fe4/psycopg2_binary-2.9.12-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2", size = 3823184, upload-time = "2026-04-20T23:35:25.92Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a0/bc2fef74b106fa345567122a0659e6d94512ed7dc0131ec44c9e5aba3725/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:840066105706cd2eb29b9a1c2329620056582a4bf3e8169dec5c447042d0869f", size = 4579157, upload-time = "2026-04-20T23:35:28.542Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/d4e3b2005d3de607ca4fbb0e8742e248056e52184a6b94ebda3c1c2c329b/psycopg2_binary-2.9.12-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:863f5d12241ebe1c76a72a04c2113b6dc905f90b9cef0e9be0efd994affd9354", size = 4274970, upload-time = "2026-04-20T23:35:30.418Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/42/c9853f8db3967fe08bcde11f53d53b85d351750cae726ce001cb68afa9c1/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a99eaab34a9010f1a086b126de467466620a750634d114d20455f3a824aae033", size = 5895175, upload-time = "2026-04-20T23:35:33.584Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/b82b5601a97630308bef079f545ffec481bbbc795c2ba5ec416a01d03f60/psycopg2_binary-2.9.12-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd7dc5463ccd61845ac37b7012d0f35a1548df9febe14f8dd549be4a0bc81e", size = 4110658, upload-time = "2026-04-20T23:35:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/62/8c/32ca69b0389ef25dd22937bf9e8fbe2ce27aea20b05ded48c4ce4cb42475/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:54a0dfecab1b48731f934e06139dfe11e24219fb6d0ceb32177cf0375f14c7b5", size = 3656251, upload-time = "2026-04-20T23:35:37.854Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/29/96992a2b59e3b9d730fcf9612d0a387305025dc867a9fc490a9e496e074e/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:96937c9c5d891f772430f418a7a8b4691a90c3e6b93cf72b5bd7cad8cbca32a5", size = 3301810, upload-time = "2026-04-20T23:35:39.927Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
+    { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "25.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/44/fdd3a4377807b7dcabe2d4b5aa99dbbc98e2e5df3f1ca4e7f0aec492d987/pyarrow-25.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:149730a3d1f0fb59d663a0b8aa210adfd9c17c27cd94a0d143e60daea8320d4e", size = 35850884, upload-time = "2026-07-10T08:26:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/71/9f053177a7709b8c90abb00a2375b916286f9f0d6cfb21a5cadd4ef811e8/pyarrow-25.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:0721332c30fdd453fdd1fc203b2ac1f4c9db5aea28fa38d41f2574c4b068b9ec", size = 37616197, upload-time = "2026-07-10T08:26:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1a/22bfb6597dcdc861fa83c39c06e1457cb56f698940eff42fbb25de30e8e5/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fa1482b3da10cac2d4db6e26b81da543e237616af2ef6d466018b31ca586496f", size = 46841966, upload-time = "2026-07-10T08:27:07.685Z" },
+    { url = "https://files.pythonhosted.org/packages/55/0e/cd705c042bc4fe7022478db577fcab4abdcfabb9bc37ab7a75556b3fcb2b/pyarrow-25.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5d1dbf24e151042f2fa3c129563f65d66674128868496fb008c4272b16bdf778", size = 50088993, upload-time = "2026-07-10T08:27:14.268Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ee/d822e1ee31fe31ec5d057210e0605c950b975dcd8d9a332976cc859a9df8/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:20887a762dd61dcc530f93a140840ab1f6aa7836b33270e42d627ab3cf11e537", size = 49941005, upload-time = "2026-07-10T08:27:21.274Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1b/207a90cc64619a095eb75a263ae069735f2810056d43c667befd573ec083/pyarrow-25.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58d1ab556b0cea1c93fdb799b24ad58adb2f2a2788dbce782a94f64ae1a5cc9b", size = 53112355, upload-time = "2026-07-10T08:27:27.911Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/fe/81d1e5f8beed15c01e98649d5c6e2167b67fd395884a2488f18bf1cf0dba/pyarrow-25.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f356afe61186395c861d5cd63dc21ff7d5fa335012a4668d979257df7fea0f5", size = 27945954, upload-time = "2026-07-10T08:27:32.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c8/098ce17d778fd9d29e40bb8c5f19a40cc90c3f0b46c9057b0d7993f42f54/pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc", size = 35844549, upload-time = "2026-07-10T08:27:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/66/24c28877219abf6263d909b1592c97ff82c59f13a59acbed11fc87c0654f/pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e", size = 37610397, upload-time = "2026-07-10T08:27:43.803Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/6d1d5f5aff317ec5de9421594679ed51ed828fe7e2ce209327f819d801e4/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be", size = 46841701, upload-time = "2026-07-10T08:27:49.741Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5d/f790fb6965ab54c9da0dda7856abc75fd0d7648d865f8d603c111d203a64/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9", size = 50090118, upload-time = "2026-07-10T08:27:56.051Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/faf025357ebf31bc96777f234277aa31e2aeca6dd4ecaa391f29085473c2/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d", size = 49945559, upload-time = "2026-07-10T08:28:01.927Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a1/bd051871708ea99a5e0fc711926c26c6f2c6d0130c7aaac8093e34998af6/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1", size = 53114238, upload-time = "2026-07-10T08:28:08.594Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/31/737f0c3cffcd6af647849477d1dd68045deac2e3963c3f9f211bedc48540/pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18", size = 27861162, upload-time = "2026-07-10T08:28:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c7/581ccbcdb3d897eb2893328d68db3d52eca373bf2a7e964d0a6276b8e85b/pyarrow-25.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:72132b9a8a0a1840197794d4dea26080069b6b0981c116bc078762dc9691b21b", size = 35878945, upload-time = "2026-07-10T08:28:18.222Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d1/ccb01db7329ea0411ef4fbd9b62a04d3268b36777d4e758d5e39b91ddeab/pyarrow-25.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e009ef945e498dca2f050ea10d2e9764cb44017254826fc4574fdb8d2530173b", size = 37630854, upload-time = "2026-07-10T08:28:23.452Z" },
+    { url = "https://files.pythonhosted.org/packages/af/9f/2d81ba89d1e4198d0cb25fe7529de936830fdaec0db926bb52a1ef7080d4/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f57a39dbcb416345401c2e77a4373669b45fd111a1768e6cf267a7a0607ff0ec", size = 46905617, upload-time = "2026-07-10T08:28:29.376Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/0ed312ec800fb536f93783215126cee4b8977dcfeccba6f0f44df0cc87d7/pyarrow-25.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:447df764beb07c544f0178a5f6b70ef44b9ecf382b3cdfad4c2d7867353c3887", size = 50119765, upload-time = "2026-07-10T08:28:35.826Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/cab5063ba0c4d46a9f6b4b7eb1c9029dc0302d65cd5ab3510c949a386568/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac5dfeee59f9ceb4d45ba76e83b026c38c24334135bb329d8274baa49cec3c62", size = 50027563, upload-time = "2026-07-10T08:28:43.848Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/fb/4d24f1b7fe2e042dc4ef315ef75e4e702d8e46fe10c37e63caff00502b03/pyarrow-25.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0f100dacf2c0f400601664a79d1a907ced4740514bb2b00917341038e2ce76f", size = 53162437, upload-time = "2026-07-10T08:28:52.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/65/da20806de93ca6ee91e72cb6a9b08b3ac890b46efc8d94a7326c651c4c81/pyarrow-25.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:2e093efbecb5317372f819228fa4b4e6157eee48d3f0a7b0303705ebf81a7104", size = 28613262, upload-time = "2026-07-10T08:29:47.544Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9f/c632afb1d3ef4a7814cee236718235f3a47eac46e97eb87df40f550b6b48/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:26be35b80780d2d21f4bae3d568b1666337c3a89722cc1794c956a77017cb24e", size = 36120702, upload-time = "2026-07-10T08:28:59.577Z" },
+    { url = "https://files.pythonhosted.org/packages/36/0a/093d53a0e72ad06e45d6443e00651bbc2d21af4211295086cbf4d873d3b9/pyarrow-25.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:6f4812bfbf11ca7d8faf59eb8fff8bf4dd25ce3a38b62baa010cc17a0926d1b2", size = 37750674, upload-time = "2026-07-10T08:29:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/18/b37fc31a69cff4bdfb8842683def5612f551b93fff6f44375e4a4a6a5535/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b8af8ceedf0c9c160fd2b63440f2d205b9404db85866c1217bfea601de7cfb50", size = 46912304, upload-time = "2026-07-10T08:29:14.656Z" },
+    { url = "https://files.pythonhosted.org/packages/32/35/5cae19ba72493e5598022468b56f6a5571f399f485bf412f157356476caa/pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c70a5fd9a82bd1a702fd482bdc62d38dcb672fb2b449b1d7c0d7d1f4be7b7bfe", size = 50073652, upload-time = "2026-07-10T08:29:22.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a5/ddd508424bdfd5e6945765e9e2ffc687e2f6115972badc8ecf423076c407/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc", size = 50058654, upload-time = "2026-07-10T08:29:29.689Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a4/324d0db203ff5eebe8694ec2d6ec5a23f9aaa5d02e5b8c692914c518c33c/pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0", size = 53140153, upload-time = "2026-07-10T08:29:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/8d/d236e9c82fe315f9128885c8be3ec719f41965a1eb6b6f4b42470904cd41/pyarrow-25.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:13240f0d3dc5932ccd0bfa90cd76d835680b9d94a7661c635df4b703d40ce849", size = 28743657, upload-time = "2026-07-10T08:29:42.742Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/da/4bef7ce7bb989b222aa4785a413896dbec53306dfc59c6ce7d16a7ffbd6a/s3transfer-0.19.1.tar.gz", hash = "sha256:d3d6371dc3f1e5c5427b2b457bcf13bcf87bec334c95aed18642eae61f6926f3", size = 165354, upload-time = "2026-07-10T19:32:04.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl", hash = "sha256:d5fd7005ee39307455ad5f310b5ea67f4b1960d7fed5b3671ee50c249de675de", size = 90072, upload-time = "2026-07-10T19:32:03.673Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/tests/refresh/README.md
+++ b/tests/refresh/README.md
@@ -1,0 +1,50 @@
+# Loader validation kit (scripts/refresh/refresh.py)
+
+Local, self-contained validation of the daily R2 → Postgres refresh loader —
+no droplet, no R2 required.
+
+```bash
+# 1. Fixture database: the loader's exact table surface + the restricted role
+createdb -h localhost -U postgres enigma_pg_refreshtest
+psql -h localhost -U postgres -d enigma_pg_refreshtest -f tests/refresh/schema_fixture.sql
+psql -h localhost -U postgres -d enigma_pg_refreshtest \
+    -c "INSERT INTO enigma.issue (id1) VALUES (1001), (1002);"
+
+# 2. Role parity: all three must FAIL with permission denied / must be owner
+PGPASSWORD=refreshtest psql -h localhost -U webbsite_refresh -d enigma_pg_refreshtest \
+    -c "DELETE FROM ccass.quotes" -c "TRUNCATE ccass.quotes" -c "DROP TABLE ccass.quotes"
+
+# 3. Synthetic feed (R2 layout: 8 <dataset>/data.parquet + _manifest.json)
+uv run --script tests/refresh/make_fixture.py /tmp/refresh-fixture
+
+# 4. The ladder
+export DATABASE_URL=postgresql://webbsite_refresh:refreshtest@localhost:5432/enigma_pg_refreshtest
+export REFRESH_USERID=99
+uv run --script scripts/refresh/refresh.py --dry-run --source /tmp/refresh-fixture  # exit 0, rollback
+uv run --script scripts/refresh/refresh.py --source /tmp/refresh-fixture            # exit 0, commits
+uv run --script scripts/refresh/refresh.py --source /tmp/refresh-fixture            # exit 0, "up to date"
+```
+
+The happy-path fixture also exercises the **quarantine**: issueid `9000001`
+(renavon-minted, absent from `enigma.issue`) loads everywhere EXCEPT
+`enigma.issuedshares`, where it is logged and excluded.
+
+## Negatives (each must exit 1 with nothing committed)
+
+Reset the watermarks between runs — a prior successful load leaves the
+fixture DB "up to date" and the loader no-ops before validation:
+
+```sql
+UPDATE enigma.log SET val='2025-10-17' WHERE name='CCASSdateDone';
+UPDATE enigma.log SET val='2025-10-10' WHERE name IN ('MBquotesDate','GEMquotesDate');
+```
+
+| fixture flag | trips |
+|---|---|
+| `--poison` | bigchanges `abs(stkchg) > 100` sanity bound |
+| `--bad-counts` | staged rows != manifest rows |
+| `--pre-freeze` | a row dated on/before 2025-10-10 (the freeze guard) |
+| (delete a log row) | `enigma.log keys missing` pre-flight |
+
+After any negative, verify no rows landed and `MBquotesDate` is still
+`2025-10-10`.

--- a/tests/refresh/make_fixture.py
+++ b/tests/refresh/make_fixture.py
@@ -1,0 +1,170 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["pyarrow>=16"]
+# ///
+"""Generate a local webbsite-refresh feed fixture for refresh.py --source.
+
+Writes the R2 layout (8 <dataset>/data.parquet + _manifest.json) with a tiny
+synthetic dataset: 3 issueids — 1001 and 1002 exist in the fixture DB's
+enigma.issue; 9000001 is a renavon-minted id that must be QUARANTINED on the
+issuedshares path (and load fine everywhere else — only issuedshares carries
+the FK).
+
+Negatives:
+  --poison      absurd bigchanges stkchg (=250) -> loader must exit 1
+  --bad-counts  manifest rows off by one on quotes -> loader must exit 1
+  --pre-freeze  one holdings row dated 2025-10-10 -> loader must exit 1
+
+Usage:
+    uv run --script tests/refresh/make_fixture.py /tmp/refresh-fixture [--poison ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+D1, D2 = date(2026, 7, 16), date(2026, 7, 17)
+ISSUE_A, ISSUE_B, ISSUE_MINTED = 1001, 1002, 9000001
+
+
+def _id(*parts) -> str:
+    return hashlib.md5("-".join(map(str, parts)).encode()).hexdigest()
+
+
+def _write(out: Path, dataset: str, table: pa.Table) -> dict:
+    d = out / dataset
+    d.mkdir(parents=True, exist_ok=True)
+    pq.write_table(table, d / "data.parquet")
+    return {"key": f"fixture/{dataset}/data.parquet", "rows": table.num_rows}
+
+
+def build(out: Path, poison: bool, bad_counts: bool, pre_freeze: bool) -> None:
+    tables: dict[str, dict] = {}
+
+    holdings_dates = [date(2025, 10, 10) if pre_freeze else D1, D1, D2, D2]
+    holdings = pa.table(
+        {
+            "partid": pa.array([1, 2, 1, 2], pa.int64()),
+            "issueid": pa.array([ISSUE_A, ISSUE_A, ISSUE_B, ISSUE_MINTED], pa.int64()),
+            "holding": pa.array([1000, 2000, 3000, 4000], pa.int64()),
+            "atdate": pa.array(holdings_dates, pa.date32()),
+            "id": [_id("h", i) for i in range(4)],
+        }
+    )
+    e = _write(out, "webbsite_ccass_holdings", holdings)
+    e["max_atdate"] = str(D2)
+    tables["webbsite_ccass_holdings"] = e
+
+    dailylog = pa.table(
+        {
+            "atdate": pa.array([D1, D2], pa.date32()),
+            "issueid": pa.array([ISSUE_A, ISSUE_B], pa.int64()),
+            **{
+                c: pa.array([10, 20], pa.int64())
+                for c in (
+                    "intermedhldg", "intermedcnt", "nciphldg", "ncipcnt",
+                    "ciphldg", "cipcnt", "c5", "c10", "custhldg", "brokhldg",
+                )
+            },
+            "id": [_id("d", i) for i in range(2)],
+        }
+    )
+    e = _write(out, "webbsite_ccass_dailylog", dailylog)
+    e["max_atdate"] = str(D2)
+    tables["webbsite_ccass_dailylog"] = e
+
+    bigchanges = pa.table(
+        {
+            "atdate": pa.array([D2], pa.date32()),
+            "issueid": pa.array([ISSUE_A], pa.int64()),
+            "partid": pa.array([1], pa.int64()),
+            "stkchg": pa.array([250.0 if poison else 0.012], pa.float64()),
+            "prevdate": pa.array([D1], pa.date32()),
+            "id": [_id("b", 0)],
+        }
+    )
+    e = _write(out, "webbsite_ccass_bigchanges", bigchanges)
+    e["max_atdate"] = str(D2)
+    tables["webbsite_ccass_bigchanges"] = e
+
+    issuedshares = pa.table(
+        {
+            "issueid": pa.array([ISSUE_A, ISSUE_MINTED], pa.int64()),
+            "atdate": pa.array([D2, D2], pa.date32()),
+            "outstanding": pa.array([5_000_000.0, 123.0], pa.float64()),
+            "id": [_id("i", i) for i in range(2)],
+        }
+    )
+    e = _write(out, "webbsite_issuedshares", issuedshares)
+    e["max_atdate"] = str(D2)
+    tables["webbsite_issuedshares"] = e
+
+    def quote_cols(n: int, key_name: str, keys: list[int]) -> dict:
+        return {
+            key_name: pa.array(keys, pa.int64() if key_name == "issueid" else pa.int32()),
+            "atdate": pa.array([D2] * n, pa.date32()),
+            **{
+                c: pa.array([1.5] * n, pa.float64())
+                for c in ("prevclose", "closing", "ask", "bid", "high", "low", "vol", "turn")
+            },
+            "susp": pa.array([False] * n),
+            "newsusp": pa.array([False] * n),
+            "noclose": pa.array([False] * n),
+        }
+
+    quotes = pa.table({**quote_cols(2, "issueid", [ISSUE_A, ISSUE_B]), "id": [_id("q", i) for i in range(2)]})
+    e = _write(out, "webbsite_quotes", quotes)
+    e["max_atdate"] = str(D2)
+    if bad_counts:
+        e["rows"] += 1  # manifest lies -> staged-count validation must exit 1
+    tables["webbsite_quotes"] = e
+
+    pquotes = pa.table({**quote_cols(1, "issueid", [ISSUE_A]), "id": [_id("p", 0)]})
+    e = _write(out, "webbsite_pquotes", pquotes)
+    e["max_atdate"] = str(D2)
+    tables["webbsite_pquotes"] = e
+
+    unquotes = pa.table({**quote_cols(1, "stockcode", [17001]), "id": [_id("u", 0)]})
+    e = _write(out, "webbsite_unquotes", unquotes)
+    e["max_atdate"] = str(D2)
+    tables["webbsite_unquotes"] = e
+
+    calendar = pa.table(
+        {
+            "tradedate": pa.array([D1, D2], pa.date32()),
+            "settledate": pa.array([date(2026, 7, 20), date(2026, 7, 21)], pa.date32()),
+            "deferred": pa.array([False, False]),
+            "id": [_id("c", i) for i in range(2)],
+        }
+    )
+    e = _write(out, "webbsite_calendar", calendar)
+    e["max_atdate"] = str(D2)
+    tables["webbsite_calendar"] = e
+
+    manifest = {
+        "completed_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "tables": tables,
+    }
+    (out / "_manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    print(f"fixture written to {out} (poison={poison} bad_counts={bad_counts} pre_freeze={pre_freeze})")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("out", type=Path)
+    p.add_argument("--poison", action="store_true")
+    p.add_argument("--bad-counts", action="store_true")
+    p.add_argument("--pre-freeze", action="store_true")
+    args = p.parse_args()
+    build(args.out, args.poison, args.bad_counts, args.pre_freeze)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/refresh/schema_fixture.sql
+++ b/tests/refresh/schema_fixture.sql
@@ -1,0 +1,178 @@
+-- Loader-surface schema fixture for local refresh.py validation.
+--
+-- NOT a restore: just the tables the loader touches, copied from
+-- database/migrations/001_post_pgloader.sql (same columns, PKs, the
+-- issuedshares trigger + FK), plus a MINIMAL enigma.issue (the loader only
+-- reads id1 for the FK-quarantine check) and the webbsite_refresh role with
+-- exactly the runbook's grants — so role-parity negatives (DELETE must fail)
+-- run locally too.
+--
+-- Usage (fresh scratch database):
+--   createdb -h localhost -U postgres enigma_pg_refreshtest
+--   psql -h localhost -U postgres -d enigma_pg_refreshtest -f tests/refresh/schema_fixture.sql
+
+CREATE SCHEMA IF NOT EXISTS ccass;
+CREATE SCHEMA IF NOT EXISTS enigma;
+
+CREATE TABLE ccass.holdings (
+    partid integer NOT NULL,
+    issueid integer NOT NULL,
+    holding bigint NOT NULL,
+    atdate date NOT NULL,
+    PRIMARY KEY (issueid, partid, atdate)
+);
+
+CREATE TABLE ccass.parthold (
+    partid integer NOT NULL,
+    issueid integer NOT NULL,
+    holding bigint NOT NULL,
+    atdate date NOT NULL,
+    PRIMARY KEY (partid, issueid, atdate)
+);
+
+CREATE TABLE ccass.dailylog (
+    atdate date NOT NULL,
+    issueid integer NOT NULL,
+    intermedhldg numeric DEFAULT '0'::numeric NOT NULL,
+    intermedcnt integer DEFAULT 0 NOT NULL,
+    nciphldg numeric DEFAULT '0'::numeric NOT NULL,
+    ncipcnt integer DEFAULT 0 NOT NULL,
+    ciphldg numeric DEFAULT '0'::numeric NOT NULL,
+    cipcnt integer DEFAULT 0 NOT NULL,
+    c5 numeric DEFAULT '0'::numeric NOT NULL,
+    c10 numeric DEFAULT '0'::numeric NOT NULL,
+    custhldg numeric DEFAULT '0'::numeric NOT NULL,
+    brokhldg numeric DEFAULT '0'::numeric NOT NULL,
+    PRIMARY KEY (issueid, atdate)
+);
+
+CREATE TABLE ccass.bigchanges (
+    atdate date NOT NULL,
+    issueid integer NOT NULL,
+    partid integer NOT NULL,
+    stkchg double precision,
+    prevdate date,
+    PRIMARY KEY (atdate, issueid, partid)
+);
+
+CREATE TABLE ccass.quotes (
+    issueid integer NOT NULL,
+    atdate date NOT NULL,
+    prevclose double precision DEFAULT '0'::double precision,
+    closing double precision DEFAULT '0'::double precision NOT NULL,
+    ask double precision DEFAULT '0'::double precision NOT NULL,
+    bid double precision DEFAULT '0'::double precision NOT NULL,
+    high double precision DEFAULT '0'::double precision NOT NULL,
+    low double precision DEFAULT '0'::double precision NOT NULL,
+    vol numeric DEFAULT '0'::numeric NOT NULL,
+    turn numeric DEFAULT '0'::numeric NOT NULL,
+    susp boolean NOT NULL,
+    newsusp boolean NOT NULL,
+    noclose boolean NOT NULL,
+    PRIMARY KEY (issueid, atdate)
+);
+CREATE UNIQUE INDEX quotes_nozero ON ccass.quotes (issueid, noclose, atdate);
+
+CREATE TABLE ccass.pquotes (
+    issueid integer NOT NULL,
+    atdate date NOT NULL,
+    prevclose double precision DEFAULT '0'::double precision NOT NULL,
+    closing double precision DEFAULT '0'::double precision NOT NULL,
+    ask double precision DEFAULT '0'::double precision NOT NULL,
+    bid double precision DEFAULT '0'::double precision NOT NULL,
+    high double precision DEFAULT '0'::double precision NOT NULL,
+    low double precision DEFAULT '0'::double precision NOT NULL,
+    vol numeric DEFAULT '0'::numeric NOT NULL,
+    turn numeric DEFAULT '0'::numeric NOT NULL,
+    susp boolean NOT NULL,
+    newsusp boolean NOT NULL,
+    noclose boolean NOT NULL,
+    PRIMARY KEY (issueid, atdate)
+);
+
+CREATE TABLE ccass.unquotes (
+    stockcode integer NOT NULL,
+    atdate date NOT NULL,
+    prevclose double precision DEFAULT '0'::double precision,
+    closing double precision DEFAULT '0'::double precision NOT NULL,
+    ask double precision DEFAULT '0'::double precision NOT NULL,
+    bid double precision DEFAULT '0'::double precision NOT NULL,
+    high double precision DEFAULT '0'::double precision NOT NULL,
+    low double precision DEFAULT '0'::double precision NOT NULL,
+    vol numeric DEFAULT '0'::numeric NOT NULL,
+    turn numeric DEFAULT '0'::numeric NOT NULL,
+    susp boolean NOT NULL,
+    newsusp boolean NOT NULL,
+    noclose boolean NOT NULL,
+    PRIMARY KEY (stockcode, atdate)
+);
+CREATE UNIQUE INDEX unquotes_nozero ON ccass.unquotes (stockcode, noclose, atdate);
+
+CREATE TABLE ccass.calendar (
+    tradedate date NOT NULL,
+    settledate date NOT NULL,
+    deferred boolean NOT NULL,
+    PRIMARY KEY (tradedate)
+);
+
+-- Minimal issue dimension: the loader reads ONLY id1 (FK + quarantine).
+CREATE TABLE enigma.issue (
+    id1 integer NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE enigma.issuedshares (
+    issueid integer DEFAULT 0 NOT NULL,
+    atdate date NOT NULL,
+    outstanding double precision,
+    modified timestamp with time zone,
+    userid integer DEFAULT 0 NOT NULL,
+    PRIMARY KEY (issueid, atdate),
+    CONSTRAINT issuedshares_issue FOREIGN KEY (issueid)
+        REFERENCES enigma.issue(id1) ON UPDATE RESTRICT ON DELETE CASCADE
+);
+
+CREATE FUNCTION enigma.on_update_current_timestamp_issuedshares() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+BEGIN
+   NEW.modified = now();
+   RETURN NEW;
+END;
+$$;
+CREATE TRIGGER on_update_current_timestamp BEFORE UPDATE ON enigma.issuedshares
+    FOR EACH ROW EXECUTE FUNCTION enigma.on_update_current_timestamp_issuedshares();
+
+CREATE TABLE enigma.log (
+    name character varying(255) NOT NULL PRIMARY KEY,
+    val character varying(255) NOT NULL,
+    descrip character varying(255) DEFAULT NULL::character varying
+);
+
+-- The frozen-era watermarks (the loader's pre-flight requires these to exist).
+INSERT INTO enigma.log (name, val) VALUES
+    ('CCASSdateDone', '2025-10-17'),
+    ('MBquotesDate', '2025-10-10'),
+    ('GEMquotesDate', '2025-10-10');
+
+-- ---------------------------------------------------------------------------
+-- The restricted loader role — EXACTLY the runbook's grants (deploy/README.md)
+-- so local role-parity negatives (DELETE/TRUNCATE/DDL must all fail) mean
+-- something. NO DELETE, NO TRUNCATE, NO DDL.
+-- ---------------------------------------------------------------------------
+DO $$ BEGIN
+    CREATE ROLE webbsite_refresh LOGIN PASSWORD 'refreshtest';
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+GRANT CONNECT, TEMPORARY ON DATABASE enigma_pg_refreshtest TO webbsite_refresh;
+GRANT USAGE ON SCHEMA ccass, enigma TO webbsite_refresh;
+GRANT SELECT, INSERT, UPDATE ON
+    ccass.holdings, ccass.parthold, ccass.dailylog, ccass.bigchanges,
+    ccass.quotes, ccass.pquotes, ccass.unquotes, ccass.calendar,
+    enigma.issuedshares
+    TO webbsite_refresh;
+GRANT SELECT ON enigma.issue TO webbsite_refresh;
+GRANT SELECT, UPDATE (val) ON enigma.log TO webbsite_refresh;
+GRANT MAINTAIN ON
+    ccass.holdings, ccass.parthold, ccass.dailylog, ccass.bigchanges,
+    ccass.quotes, ccass.pquotes, ccass.unquotes, ccass.calendar,
+    enigma.issuedshares
+    TO webbsite_refresh;


### PR DESCRIPTION
## Summary

W-PRE — the consuming end of the renavon `webbsite-refresh` feed (renavon #756 Phase 3, renavon PRs #817/#818). This turns the frozen 2025-10-10 archive into a **daily-refreshed** one.

- **`scripts/refresh/refresh.py`** (PEP 723 uv script + committed lock): manifest-gated pull from `r2://hkdata/webbsite-refresh/`, ONE-transaction staged/validated/idempotent upsert into the 9 targets (`ccass.holdings`+`parthold` from one file; `enigma.issuedshares` with FK quarantine + `modified`/`userid`), forward-only `enigma.log` watermark advance (`MB/GEM` = quotes max; `CCASSdateDone` = min(ccass, MB, GEM)), then ANALYZE + a freshness-gated healthcheck ping. `--dry-run`/`--confirm`/`--source`/`--table`; exit 0/1/2 = ok/validation/infra.
- **systemd**: `webbsite-refresh.service` (oneshot, `User=webbsite`, sandbox mirrors `webbsite.service`) + `.timer` (02:45 + 06:45 UTC; second firing is the self-healing retry — loader no-ops when already loaded).
- **Runbook** (`deploy/README.md`): delete-less `webbsite_refresh` role with verify-the-negative step, pre-flight, `/etc/webbsite/refresh-env`, Object-Read-only R2 token, supervised first run, monitoring, corrections/rollback.
- **ADR 001**: pull not push · manifest-gated · one-txn · delete-less role · freeze guard · watermarks atomic with data · TTL ladder instead of purges (W-PRD, #25).
- **`tests/refresh/`**: loader-surface schema fixture (incl. the restricted role), synthetic feed generator with `--poison`/`--bad-counts`/`--pre-freeze`, and the validation ladder README.

## Validation (all run locally against a fixture DB)

| check | result |
|---|---|
| role parity (DELETE/TRUNCATE/DDL as `webbsite_refresh`) | ✅ all denied |
| `--dry-run` | ✅ full staging + quarantine, rolled back |
| real run | ✅ both holdings mirrors; issueid 9000001 quarantined; `modified`/`userid` set; watermarks advanced |
| idempotent rerun | ✅ "up to date", zero writes |
| `--poison` / `--bad-counts` / `--pre-freeze` / missing log key | ✅ each exit 1, zero rows, watermarks untouched |
| **real renavon dev feed** (3.9M rows from `webbsite-refresh-dev`) | ✅ loaded in 43s; `CCASSdateDone = min(2026-01-06, 2026-07-17)` exactly as designed |

Droplet install (role + env + units + supervised run) follows the new runbook after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)