### PR TITLE
Recover the ExecReload the box had and the repo did not; add deploy/site.toml

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,5 +1,16 @@
 # Deploy artefacts (droplet `webbsite-web`)
 
+> **Deploy knobs now live in `deploy/site.toml`, not only in `/etc/webbsite/env`.**
+> `site-deploy`'s poller reads that file every tick, and it wins over the
+> environment. Secrets stay in `/etc/webbsite/env`. Two invariants are recorded
+> there because they are not independent: the reload verb is `reload` (SIGHUP),
+> which needs `ExecReload` in the unit *and* `preload_app = False` in
+> `gunicorn.conf.py` — change one and you must change all three.
+>
+> The poller also now probes `/health` after the reload and refuses to purge
+> Cloudflare unless it answers, so a deploy that breaks the app leaves the edge
+> serving the cached old site instead of a cold broken one.
+
 Hosts the Webb-site archive (the late David Webb's CC-BY data; frozen baseline 2025-10-10,
 **refreshed daily** from renavon pipelines — see "Daily data refresh" below) on a single
 DigitalOcean droplet, migrated off Render. Self-hosted PostgreSQL + gunicorn under

--- a/deploy/site.toml
+++ b/deploy/site.toml
@@ -1,0 +1,49 @@
+# How webbsite deploys. Read by site-deploy's auto-deploy.sh on every tick.
+#
+# This file exists so the knobs that decide deploy behaviour are reviewable in a
+# pull request. They used to live only in /etc/webbsite/env on the droplet,
+# where nothing diffs them and nothing notices drift — which is how the
+# committed unit in deploy/systemd/ ended up missing an ExecReload the box had
+# been relying on for months.
+#
+# Secrets are NOT here and must not be: CF_CACHE_PURGE_TOKEN, DATABASE_URL and
+# SECRET_KEY stay in /etc/webbsite/env, which is not in git.
+
+[deploy]
+# SIGHUP, not a restart. This is load-bearing in both directions:
+#   * deploy/systemd/webbsite.service must keep ExecReload=/bin/kill -HUP $MAINPID
+#     — `systemctl reload` on a unit without it fails outright.
+#   * gunicorn.conf.py must keep preload_app = False — gunicorn does not reload
+#     application code on HUP when preloaded, so recycled workers fork from the
+#     stale master image while Jinja reads the NEW templates from disk. That skew
+#     500'd every orgdata.asp request on 2026-07-16.
+# Change any one of these three and you must change all three.
+reload = "reload"
+
+# Matches the live unit's ExecStart. --no-dev keeps test/lint deps off the box.
+uv_args = "--frozen --no-dev"
+
+# gunicorn binds 127.0.0.1:8000; Caddy fronts it on :443.
+port = 8000
+
+# Probed after the reload and BEFORE the Cloudflare purge. Purging first would
+# refill the edge from a cold or broken origin; failing here leaves the edge
+# serving the cached old site, which is the better failure.
+health_path = "/health"
+
+# A 200 from a half-booted worker is not health. /health returns {"status":"ok"}
+# (webbsite/__init__.py:194), so require the body, not just the status code.
+#
+# Match the VALUE, not the whole object: the live response is compact
+# ({"status":"ok"}, no space after the colon) and a Flask/jsonify change could
+# alter the separators without changing the meaning. Checked against production
+# rather than assumed — the spaced version would have failed every deploy.
+health_match = '"ok"'
+
+# HTML carries a 30-day CDN-Cache-Control, so a code deploy is invisible without
+# the purge (deploy/README.md). The daily R2 -> Postgres refresh deliberately
+# does NOT purge — its TTL ladder self-heals within 4h.
+cf_zone_id = "c754c09daa8fb9cce8e4977d44cbd246"
+
+# No build_service: webbsite is Postgres-backed and has no snapshot builder.
+# No Tailwind either — there is no static/src.css, so the CSS step auto-skips.

--- a/deploy/systemd/webbsite.service
+++ b/deploy/systemd/webbsite.service
@@ -1,5 +1,13 @@
-# Captured from the live droplet webbsite-web. Source of truth — keep in sync with the box.
-# Serves the frozen Webb-site archive (gunicorn) on 127.0.0.1:8000; Caddy fronts it on :443.
+# Mirrors the unit on webbsite-web. Serves the frozen Webb-site archive
+# (gunicorn) on 127.0.0.1:8000; Caddy fronts it on :443.
+#
+# This file called itself "source of truth — keep in sync with the box" and had
+# already drifted from it on two lines by 2026-09-06: the box carried
+# `--no-dev` and an ExecReload that were never committed back. A mirror kept in
+# sync by hand is a mirror that drifts, and nothing detected it for months.
+# `deploy/site.toml` plus a converge step is the fix; until that lands, this
+# file is a *mirror*, not an authority, and `systemctl cat webbsite.service` on
+# the box is what settles a disagreement.
 [Unit]
 Description=Webb-site Flask
 After=network-online.target postgresql.service
@@ -12,7 +20,15 @@ Group=webbsite
 WorkingDirectory=/srv/webbsite
 EnvironmentFile=/etc/webbsite/env
 Environment=HOME=/srv/webbsite
-ExecStart=/usr/local/bin/uv run --frozen gunicorn -c gunicorn.conf.py --bind 127.0.0.1:8000 app:app
+ExecStart=/usr/local/bin/uv run --frozen --no-dev gunicorn -c gunicorn.conf.py --bind 127.0.0.1:8000 app:app
+# Load-bearing, and it was missing here. The deploy contract is `systemctl
+# reload` (site-deploy's DEPLOY_RELOAD=reload, set in /etc/webbsite/env), and
+# on a unit with no ExecReload systemd answers "Job type reload is not
+# applicable" — auto-deploy.sh would exit 1 on every single deploy. It works
+# only because the box has this line. Pairs with gunicorn.conf.py's
+# `preload_app = False`: SIGHUP reloads code+templates only when not preloaded
+# (the 2026-07-16 outage). Change either one and you must change both.
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=2
 StandardOutput=journal


### PR DESCRIPTION
`deploy/systemd/webbsite.service` calls itself "source of truth — keep in sync with the box". It had drifted on two lines:

| | box | repo |
|---|---|---|
| `ExecStart` | `uv run --frozen --no-dev` | `--frozen` |
| `ExecReload` | `/bin/kill -HUP $MAINPID` | **absent** |

The second is load-bearing: the deploy contract is `systemctl reload`, and on a unit with no `ExecReload` systemd answers *"Job type reload is not applicable"*. Every deploy would fail. It works only because the box carries a line nobody committed back.

`deploy/site.toml` addresses the class rather than the instance — deploy knobs move into this repo where a PR reviews them, and site-deploy reports disagreements with the box instead of silently resolving them. Secrets stay in `/etc/webbsite/env`.

One detail worth the checking: `health_match` is `'"ok"'`, not `'"status": "ok"'`. Production returns the compact `{"status":"ok"}` with no space after the colon, so the spaced form would have failed every deploy. Verified against the live endpoint.

Merging this is also the first real exercise of the new poller — reload, health probe, then purge.